### PR TITLE
traci: add getSignals and setSignals to VehicleScope

### DIFF
--- a/src/traci_testclient/TraCITestClient.cpp
+++ b/src/traci_testclient/TraCITestClient.cpp
@@ -799,6 +799,9 @@ TraCITestClient::testAPI() {
     vehicle.setColor("0", col1);
     TraCIColor col2 = vehicle.getColor("0");
     answerLog << "    getColor:  r=" << (int)col2.r << " g=" << (int)col2.g << " b=" << (int)col2.b << " a=" << (int)col2.a << "\n";
+    int signals = vehicle.getSignals("0");
+    answerLog << "    getSignals: " << signals << "\n";
+    vehicle.setSignals("0", signals ^ TraCIAPI::VehicleScope::SIGNAL_FOGLIGHT);
     answerLog << "    getNextTLS:\n";
     std::vector<TraCINextTLSData> result = vehicle.getNextTLS("0");
     for (int i = 0; i < (int)result.size(); ++i) {

--- a/src/utils/traci/TraCIAPI.cpp
+++ b/src/utils/traci/TraCIAPI.cpp
@@ -2224,6 +2224,11 @@ TraCIAPI::VehicleScope::getDistance(const std::string& vehicleID) const {
     return myParent.getDouble(CMD_GET_VEHICLE_VARIABLE, VAR_DISTANCE, vehicleID);
 }
 
+int
+TraCIAPI::VehicleScope::getSignals(const std::string& vehicleID) const {
+    return myParent.getInt(CMD_GET_VEHICLE_VARIABLE, VAR_SIGNALS, vehicleID);
+}
+
 double
 TraCIAPI::VehicleScope::getLateralLanePosition(const std::string& vehicleID) const {
     return myParent.getDouble(CMD_GET_VEHICLE_VARIABLE, VAR_LANEPOSITION_LAT, vehicleID);
@@ -2742,6 +2747,15 @@ TraCIAPI::VehicleScope::setVia(const std::string& vehicleID, const std::vector<s
     myParent.check_resultState(inMsg, CMD_SET_VEHICLE_VARIABLE);
 }
 
+void
+TraCIAPI::VehicleScope::setSignals(const std::string& vehicleID, int signals) const {
+    tcpip::Storage content;
+    content.writeUnsignedByte(TYPE_INTEGER);
+    content.writeInt(signals);
+    myParent.send_commandSetValue(CMD_SET_VEHICLE_VARIABLE, VAR_SIGNALS, vehicleID, content);
+    tcpip::Storage inMsg;
+    myParent.check_resultState(inMsg, CMD_SET_VEHICLE_VARIABLE);
+}
 
 void
 TraCIAPI::VehicleScope::setShapeClass(const std::string& vehicleID, const std::string& clazz) const {

--- a/src/utils/traci/TraCIAPI.h
+++ b/src/utils/traci/TraCIAPI.h
@@ -638,6 +638,24 @@ public:
         LAST_TRAVEL_TIME_UPDATE(-1) {}
         virtual ~VehicleScope() {}
 
+        enum VehicleSignal {
+            SIGNAL_BLINKER_RIGHT = 1,
+            SIGNAL_BLINKER_LEFT = 2,
+            SIGNAL_BLINKER_EMERGENCY = 4,
+            SIGNAL_BRAKELIGHT = 8,
+            SIGNAL_FRONTLIGHT = 16,
+            SIGNAL_FOGLIGHT = 32,
+            SIGNAL_HIGHBEAM = 64,
+            SIGNAL_BACKDRIVE = 128,
+            SIGNAL_WIPER = 256,
+            SIGNAL_DOOR_OPEN_LEFT = 512,
+            SIGNAL_DOOR_OPEN_RIGHT = 1024,
+            SIGNAL_EMERGENCY_BLUE = 2048,
+            SIGNAL_EMERGENCY_RED = 4096,
+            SIGNAL_EMERGENCY_YELLOW = 8192,
+            SIGNAL_RESET = -1, /*< sending a negative signal resets all signals to their computed values immediately */
+        };
+
         /// @name vehicle value retrieval
         /// @{
         std::vector<std::string> getIDList() const;
@@ -657,7 +675,7 @@ public:
         libsumo::TraCIColor getColor(const std::string& vehicleID) const;
         double getLanePosition(const std::string& vehicleID) const;
         double getDistance(const std::string& vehicleID) const;
-        int getSignalStates(const std::string& vehicleID) const;
+        int getSignals(const std::string& vehicleID) const;
         double getCO2Emission(const std::string& vehicleID) const;
         double getCOEmission(const std::string& vehicleID) const;
         double getHCEmission(const std::string& vehicleID) const;
@@ -738,6 +756,7 @@ public:
         void setColor(const std::string& vehicleID, const libsumo::TraCIColor& c) const;
         void setLine(const std::string& vehicleID, const std::string& line) const;
         void setVia(const std::string& vehicleID, const std::vector<std::string>& via) const;
+        void setSignals(const std::string& vehicleID, int signals) const;
         /// @}
 
         /// @name vehicle type attribute changing shortcuts


### PR DESCRIPTION
VehicleScope::getSignalStates lacked the implementation. It has been replaced by VehicleScope::getSignals which has the same method name as its Python API equivalent.