### PR TITLE
Rework the ComparatorIdLess

### DIFF
--- a/src/jtrrouter/ROJTREdge.h
+++ b/src/jtrrouter/ROJTREdge.h
@@ -109,7 +109,7 @@ public:
 
 private:
     /// @brief Definition of a map that stores the probabilities of using a certain follower over time
-    typedef std::map<ROJTREdge*, ValueTimeLine<double>*, Named::ComparatorIdLess> FollowerUsageCont;
+    typedef std::map<ROJTREdge*, ValueTimeLine<double>*, ComparatorIdLess> FollowerUsageCont;
 
     /// @brief Storage for the probabilities of using a certain follower over time
     FollowerUsageCont myFollowingDefs;

--- a/src/microsim/MSEdgeControl.cpp
+++ b/src/microsim/MSEdgeControl.cpp
@@ -75,7 +75,7 @@ MSEdgeControl::~MSEdgeControl() {
 
 void
 MSEdgeControl::patchActiveLanes() {
-    for (std::set<MSLane*, Named::ComparatorIdLess>::iterator i = myChangedStateLanes.begin(); i != myChangedStateLanes.end(); ++i) {
+    for (std::set<MSLane*, ComparatorIdLess>::iterator i = myChangedStateLanes.begin(); i != myChangedStateLanes.end(); ++i) {
         LaneUsage& lu = myLanes[(*i)->getNumericalID()];
         // if the lane was inactive but is now...
         if (!lu.amActive && (*i)->getVehicleNumber() > 0) {

--- a/src/microsim/MSEdgeControl.h
+++ b/src/microsim/MSEdgeControl.h
@@ -218,7 +218,7 @@ private:
     std::vector<MSLane*> myWithVehicles2Integrate;
 
     /// @brief Lanes which changed the state without informing the control
-    std::set<MSLane*, Named::ComparatorIdLess> myChangedStateLanes;
+    std::set<MSLane*, ComparatorIdLess> myChangedStateLanes;
 
     /// @brief The list of active (not empty) lanes
     std::vector<SUMOTime> myLastLaneChange;

--- a/src/microsim/MSLane.cpp
+++ b/src/microsim/MSLane.cpp
@@ -1188,7 +1188,7 @@ MSLane::detectCollisions(SUMOTime timestep, const std::string& stage) {
     if (myVehicles.size() == 0 || myCollisionAction == COLLISION_ACTION_NONE) {
         return;
     }
-    std::set<const MSVehicle*, SUMOVehicle::ComparatorIdLess> toRemove;
+    std::set<const MSVehicle*, ComparatorIdLess> toRemove;
     std::set<const MSVehicle*> toTeleport;
     if (!MSAbstractLaneChangeModel::haveLateralDynamics()) {
         // no sublanes
@@ -1320,7 +1320,7 @@ MSLane::detectCollisions(SUMOTime timestep, const std::string& stage) {
     }
 
 
-    for (std::set<const MSVehicle*, SUMOVehicle::ComparatorIdLess>::iterator it = toRemove.begin(); it != toRemove.end(); ++it) {
+    for (std::set<const MSVehicle*, ComparatorIdLess>::iterator it = toRemove.begin(); it != toRemove.end(); ++it) {
         MSVehicle* veh = const_cast<MSVehicle*>(*it);
         MSLane* vehLane = veh->getLane();
         vehLane->removeVehicle(veh, MSMoveReminder::NOTIFICATION_TELEPORT, false);
@@ -1369,7 +1369,7 @@ MSLane::detectPedestrianJunctionCollision(const MSVehicle* collider, const Posit
 
 bool
 MSLane::detectCollisionBetween(SUMOTime timestep, const std::string& stage, MSVehicle* collider, MSVehicle* victim,
-                               std::set<const MSVehicle*, SUMOVehicle::ComparatorIdLess>& toRemove,
+                               std::set<const MSVehicle*, ComparatorIdLess>& toRemove,
                                std::set<const MSVehicle*>& toTeleport) const {
     if (myCollisionAction == COLLISION_ACTION_TELEPORT && ((victim->hasInfluencer() && victim->getInfluencer().isRemoteAffected(timestep)) ||
             (collider->hasInfluencer() && collider->getInfluencer().isRemoteAffected(timestep)))) {
@@ -1430,7 +1430,7 @@ MSLane::detectCollisionBetween(SUMOTime timestep, const std::string& stage, MSVe
 
 void
 MSLane::handleCollisionBetween(SUMOTime timestep, const std::string& stage, MSVehicle* collider, MSVehicle* victim,
-                               double gap, double latGap, std::set<const MSVehicle*, SUMOVehicle::ComparatorIdLess>& toRemove,
+                               double gap, double latGap, std::set<const MSVehicle*, ComparatorIdLess>& toRemove,
                                std::set<const MSVehicle*>& toTeleport) const {
     std::string prefix = "Vehicle '" + collider->getID() + "'; collision with vehicle '" + victim->getID() ;
     if (myCollisionStopTime > 0) {

--- a/src/microsim/MSLane.h
+++ b/src/microsim/MSLane.h
@@ -1107,13 +1107,13 @@ protected:
 
     /// @brief detect whether there is a collision between the two vehicles
     bool detectCollisionBetween(SUMOTime timestep, const std::string& stage, MSVehicle* collider, MSVehicle* victim,
-                                std::set<const MSVehicle*, SUMOVehicle::ComparatorIdLess>& toRemove,
+                                std::set<const MSVehicle*, ComparatorIdLess>& toRemove,
                                 std::set<const MSVehicle*>& toTeleport) const;
 
     /// @brief take action upon collision
     void handleCollisionBetween(SUMOTime timestep, const std::string& stage, MSVehicle* collider, MSVehicle* victim,
                                 double gap, double latGap,
-                                std::set<const MSVehicle*, SUMOVehicle::ComparatorIdLess>& toRemove,
+                                std::set<const MSVehicle*, ComparatorIdLess>& toRemove,
                                 std::set<const MSVehicle*>& toTeleport) const;
 
     /// @brief compute maximum braking distance on this lane

--- a/src/microsim/MSLink.h
+++ b/src/microsim/MSLink.h
@@ -202,7 +202,7 @@ public:
     ApproachingVehicleInformation getApproaching(const SUMOVehicle* veh) const;
 
     /// @brief return all approaching vehicles
-    const std::map<const SUMOVehicle*, ApproachingVehicleInformation, SUMOVehicle::ComparatorIdLess>& getApproaching() const {
+    const std::map<const SUMOVehicle*, ApproachingVehicleInformation, ComparatorIdLess>& getApproaching() const {
         return myApproachingVehicles;
     }
 
@@ -542,7 +542,7 @@ private:
     /// @brief The lane approaching this link
     MSLane* myLaneBefore;
 
-    std::map<const SUMOVehicle*, ApproachingVehicleInformation, SUMOVehicle::ComparatorIdLess> myApproachingVehicles;
+    std::map<const SUMOVehicle*, ApproachingVehicleInformation, ComparatorIdLess> myApproachingVehicles;
     std::set<MSLink*> myBlockedFoeLinks;
 
     /// @brief The position within this respond

--- a/src/microsim/devices/MSDevice_Tripinfo.h
+++ b/src/microsim/devices/MSDevice_Tripinfo.h
@@ -238,7 +238,7 @@ private:
     SUMOTime myMesoTimeLoss;
 
     /// @brief devices which may still need to produce output
-    typedef std::set<const MSDevice_Tripinfo*, Named::NamedLikeComparatorIdLess<MSDevice_Tripinfo> > DeviceSet;
+    typedef std::set<const MSDevice_Tripinfo*, ComparatorIdLess > DeviceSet;
 
     static DeviceSet myPendingOutput;
 

--- a/src/microsim/devices/MSDevice_Vehroutes.cpp
+++ b/src/microsim/devices/MSDevice_Vehroutes.cpp
@@ -382,7 +382,7 @@ MSDevice_Vehroutes::addRoute() {
 
 void
 MSDevice_Vehroutes::generateOutputForUnfinished() {
-    for (std::map<const SUMOVehicle*, MSDevice_Vehroutes*, Named::NamedLikeComparatorIdLess<SUMOVehicle> >::const_iterator it = myStateListener.myDevices.begin();
+    for (std::map<const SUMOVehicle*, MSDevice_Vehroutes*, ComparatorIdLess >::const_iterator it = myStateListener.myDevices.begin();
             it != myStateListener.myDevices.end(); ++it) {
         if (it->first->hasDeparted()) {
             it->second->writeOutput(false);

--- a/src/microsim/devices/MSDevice_Vehroutes.h
+++ b/src/microsim/devices/MSDevice_Vehroutes.h
@@ -216,7 +216,7 @@ private:
         void vehicleStateChanged(const SUMOVehicle* const vehicle, MSNet::VehicleState to);
 
         /// @brief A map for internal notification
-        std::map<const SUMOVehicle*, MSDevice_Vehroutes*, SUMOVehicle::ComparatorIdLess> myDevices;
+        std::map<const SUMOVehicle*, MSDevice_Vehroutes*, ComparatorIdLess> myDevices;
 
     };
 

--- a/src/microsim/traffic_lights/MSRailSignal.cpp
+++ b/src/microsim/traffic_lights/MSRailSignal.cpp
@@ -231,7 +231,7 @@ MSRailSignal::getAppropriateState() {
                 std::map<const MSLane*, const MSLink*>::iterator it = mySucceedingBlocksIncommingLinks.find(lane);
                 if (it != mySucceedingBlocksIncommingLinks.end()) {
                     const MSLink* inCommingLing = it->second;
-                    const std::map<const SUMOVehicle*, MSLink::ApproachingVehicleInformation, SUMOVehicle::ComparatorIdLess> approaching = inCommingLing->getApproaching();
+                    const std::map<const SUMOVehicle*, MSLink::ApproachingVehicleInformation, ComparatorIdLess> approaching = inCommingLing->getApproaching();
                     std::map<const SUMOVehicle*,  MSLink::ApproachingVehicleInformation>::const_iterator apprIt = approaching.begin();
                     for (; apprIt != approaching.end(); apprIt++) {
                         MSLink::ApproachingVehicleInformation info = apprIt->second;

--- a/src/netbuild/NBAlgorithms_Ramps.cpp
+++ b/src/netbuild/NBAlgorithms_Ramps.cpp
@@ -85,8 +85,8 @@ NBRampsComputer::computeRamps(NBNetBuilder& nb, OptionsCont& oc) {
         NBDistrictCont& dc = nb.getDistrictCont();
 
         // if an edge is part of two ramps, ordering is important
-        std::set<NBNode*, Named::ComparatorIdLess> potOnRamps;
-        std::set<NBNode*, Named::ComparatorIdLess> potOffRamps;
+        std::set<NBNode*, ComparatorIdLess> potOnRamps;
+        std::set<NBNode*, ComparatorIdLess> potOffRamps;
         for (std::map<std::string, NBNode*>::const_iterator i = nc.begin(); i != nc.end(); ++i) {
             NBNode* cur = (*i).second;
             if (mayNeedOnRamp(cur, minHighwaySpeed, maxRampSpeed, noramps)) {
@@ -96,10 +96,10 @@ NBRampsComputer::computeRamps(NBNetBuilder& nb, OptionsCont& oc) {
                 potOffRamps.insert(cur);
             }
         }
-        for (std::set<NBNode*, Named::ComparatorIdLess>::const_iterator i = potOnRamps.begin(); i != potOnRamps.end(); ++i) {
+        for (std::set<NBNode*, ComparatorIdLess>::const_iterator i = potOnRamps.begin(); i != potOnRamps.end(); ++i) {
             buildOnRamp(*i, nc, ec, dc, rampLength, dontSplit);
         }
-        for (std::set<NBNode*, Named::ComparatorIdLess>::const_iterator i = potOffRamps.begin(); i != potOffRamps.end(); ++i) {
+        for (std::set<NBNode*, ComparatorIdLess>::const_iterator i = potOffRamps.begin(); i != potOffRamps.end(); ++i) {
             buildOffRamp(*i, nc, ec, dc, rampLength, dontSplit);
         }
     }

--- a/src/netbuild/NBEdgeCont.cpp
+++ b/src/netbuild/NBEdgeCont.cpp
@@ -1311,7 +1311,7 @@ NBEdgeCont::remapIDs(bool numericaIDs, bool reservedIDs, const std::string& pref
         avoid.insert(avoid.end(), reserve.begin(), reserve.end());
     }
     IDSupplier idSupplier("", avoid);
-    std::set<NBEdge*, Named::ComparatorIdLess> toChange;
+    std::set<NBEdge*, ComparatorIdLess> toChange;
     for (EdgeCont::iterator it = myEdges.begin(); it != myEdges.end(); it++) {
         if (numericaIDs) {
             try {
@@ -1325,7 +1325,7 @@ NBEdgeCont::remapIDs(bool numericaIDs, bool reservedIDs, const std::string& pref
         }
     }
     const bool origNames = OptionsCont::getOptions().getBool("output.original-names");
-    for (std::set<NBEdge*, Named::ComparatorIdLess>::iterator it = toChange.begin(); it != toChange.end(); ++it) {
+    for (std::set<NBEdge*, ComparatorIdLess>::iterator it = toChange.begin(); it != toChange.end(); ++it) {
         NBEdge* edge = *it;
         myEdges.erase(edge->getID());
         if (origNames) {

--- a/src/netbuild/NBNodeCont.cpp
+++ b/src/netbuild/NBNodeCont.cpp
@@ -1531,7 +1531,7 @@ NBNodeCont::remapIDs(bool numericaIDs, bool reservedIDs, const std::string& pref
         avoid.insert(avoid.end(), reserve.begin(), reserve.end());
     }
     IDSupplier idSupplier("", avoid);
-    std::set<NBNode*, Named::ComparatorIdLess> toChange;
+    std::set<NBNode*, ComparatorIdLess> toChange;
     for (NodeCont::iterator it = myNodes.begin(); it != myNodes.end(); it++) {
         if (numericaIDs) {
             try {
@@ -1545,7 +1545,7 @@ NBNodeCont::remapIDs(bool numericaIDs, bool reservedIDs, const std::string& pref
         }
     }
     const bool origNames = OptionsCont::getOptions().getBool("output.original-names");
-    for (std::set<NBNode*, Named::ComparatorIdLess>::iterator it = toChange.begin(); it != toChange.end(); ++it) {
+    for (std::set<NBNode*, ComparatorIdLess>::iterator it = toChange.begin(); it != toChange.end(); ++it) {
         NBNode* node = *it;
         myNodes.erase(node->getID());
         if (origNames) {

--- a/src/utils/common/Named.h
+++ b/src/utils/common/Named.h
@@ -33,6 +33,16 @@
 #include <set>
 
 
+/// @brief Function-object for stable sorting of objects acting like Named without being derived (SUMOVehicle)
+// @note Numbers of different lenghts will not be ordered by alphanumerical sorting
+struct ComparatorIdLess {
+   template<class T>
+	bool operator()(const T* const a, const T* const b) const {
+		return a->getID() < b->getID();
+	}
+};
+
+
 // ===========================================================================
 // class definitions
 // ===========================================================================
@@ -71,18 +81,6 @@ public:
     void setID(const std::string& newID) {
         myID = newID;
     }
-
-
-    /// @brief Function-object for stable sorting of objects acting like Named without being derived (SUMOVehicle)
-    // @note Numbers of different lenghts will not be ordered by alphanumerical sorting
-    template <class NamedLike>
-    struct NamedLikeComparatorIdLess {
-       template<class T>
-        bool operator()(const T* const a, const T* const b) const {
-            return static_cast<const NamedLike*>(a)->getID() < static_cast<const NamedLike*>(b)->getID();
-        }
-    };
-    typedef NamedLikeComparatorIdLess<Named> ComparatorIdLess;
 
 
     /** @class StoringVisitor

--- a/src/utils/vehicle/SUMOVehicle.h
+++ b/src/utils/vehicle/SUMOVehicle.h
@@ -73,9 +73,6 @@ public:
      */
     virtual double getPreviousSpeed() const = 0;
 
-
-    typedef Named::NamedLikeComparatorIdLess<SUMOVehicle> ComparatorIdLess;
-
     /// @brief Destructor
     virtual ~SUMOVehicle() {}
 


### PR DESCRIPTION
This makes it compile with current compilers (GCC >= 8, Clang >= 6).
Fixes #4110.

Signed-off-by: Max Schettler <schettle@mail.uni-paderborn.de>