### PR TITLE
Enable vehicle types check in route probe detector

### DIFF
--- a/src/microsim/output/MSRouteProbe.cpp
+++ b/src/microsim/output/MSRouteProbe.cpp
@@ -69,6 +69,9 @@ MSRouteProbe::~MSRouteProbe() {
 
 bool
 MSRouteProbe::notifyEnter(SUMOVehicle& veh, MSMoveReminder::Notification reason, const MSLane* /* enteredLane */) {
+    if (!vehicleApplies(veh)) {
+        return false;
+    }
     if (reason != MSMoveReminder::NOTIFICATION_SEGMENT && reason != MSMoveReminder::NOTIFICATION_LANE_CHANGE) {
         if (myCurrentRouteDistribution.second->add(&veh.getRoute(), 1.)) {
             veh.getRoute().addReference();


### PR DESCRIPTION
Route probe detectors had already been prepared (XSD scheme, constructor) for vTypes checks. Now the vTypes are checked using MSDetectorFileOutput::vehicleApplies method.