### PR TITLE
sumolib.net fixes

### DIFF
--- a/tools/sumolib/net/lane.py
+++ b/tools/sumolib/net/lane.py
@@ -64,6 +64,8 @@ def get_allowed(allow, disallow):
         return SUMO_VEHICLE_CLASSES
     elif disallow is None:
         return allow.split()
+    elif disallow == "all":
+        return ()
     else:
         disallow = disallow.split()
         return tuple([c for c in SUMO_VEHICLE_CLASSES if c not in disallow])

--- a/tools/sumolib/net/node.py
+++ b/tools/sumolib/net/node.py
@@ -97,12 +97,15 @@ class Node:
     def getLinkIndex(self, conn):
         ret = 0
         for lane_id in self._incLanes:
-            (edge_id, index) = lane_id.split("_")
-            edge = [e for e in self._incoming if e.getID() == edge_id][0]
-            for candidate_conn in edge.getLane(int(index)).getOutgoing():
-                if candidate_conn == conn:
-                    return ret
-                ret += 1
+            lastUnderscore = lane_id.rfind("_")
+            if lastUnderscore > 0:
+                edge_id = lane_id[:lastUnderscore]
+                index = lane_id[lastUnderscore+1:]
+                edge = [e for e in self._incoming if e.getID() == edge_id][0]
+                for candidate_conn in edge.getLane(int(index)).getOutgoing():
+                    if candidate_conn == conn:
+                        return ret
+                    ret += 1
         return -1
 
     def forbids(self, possProhibitor, possProhibited):


### PR DESCRIPTION
Some stuff in sumolib.net:
**1. lane ID splitting**
Previously, edge IDs with multiple underscores cannot be handled by sumolib.net.node. These may be user-chosen edge IDs but also automatically generated ones for waitingareas. 
Now only the last underscore of the lane ID is used to derive the edge ID.
**2. lane option disallow=all**
Lead previously to allow=[list of all classes].
Signed-off-by: m-kro <m.barthauer@t-online.de>