### PR TITLE
Add router dependencies to custom examples target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ install(DIRECTORY tools/ DESTINATION share/sumo/tools
 install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ../../bin $ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/share/sumo/bin)")
 
 # custom targets
-add_custom_target(examples DEPENDS sumo netconvert
+add_custom_target(examples DEPENDS sumo netconvert dfrouter duarouter jtrrouter
     COMMAND ${PYTHON_EXECUTABLE} tools/extractTest.py -x -f tests/examples.txt -p docs/examples/runAll.py
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 add_test(exampletest ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/docs/examples/runAll.py)


### PR DESCRIPTION
The tests listed in tests/examples.test require that the executables of dfrouter, duarouter and jtrrouter are available when the python scripts are run. When they are not listed as dependencies to the custom target, the build of the examples target might fail, depending on which targets are build first. Adding the *router targets as dependencies fixes that issue.
Sidenote: Building the examples target in Debug always fails if no Release build has been made previously, as the names of all debug executables are suffixed with "D" and thus are not found/used by the python scripts.