### PR TITLE
Fix function argument names and order

### DIFF
--- a/src/libsumo/Polygon.h
+++ b/src/libsumo/Polygon.h
@@ -59,7 +59,7 @@ public:
     static void remove(const std::string& polygonID, int layer = 0);
 
     static void setFilled(std::string polygonID, bool filled);
-    static void setParameter(std::string& name, std::string& value, std::string& string);
+    static void setParameter(std::string& id, std::string& name, std::string& value);
 
     LIBSUMO_SUBSCRIPTION_API
 


### PR DESCRIPTION
The argument names and order for setParameter(...) differs between function declaration (name, value, string) and definition (id, name, value). This can lead to user errors and is fixed by this commit.