### PR TITLE
Fix AStarRouter Memory Leak

### DIFF
--- a/src/duarouter/duarouter_main.cpp
+++ b/src/duarouter/duarouter_main.cpp
@@ -31,6 +31,7 @@
 #include <string>
 #include <limits.h>
 #include <ctime>
+#include <memory>
 #include <xercesc/sax/SAXException.hpp>
 #include <xercesc/sax/SAXParseException.hpp>
 #include <utils/common/TplConvert.h>
@@ -110,29 +111,29 @@ computeRoutes(RONet& net, ROLoader& loader, OptionsCont& oc) {
         } else if (routingAlgorithm == "astar") {
             if (net.hasPermissions()) {
                 typedef AStarRouter<ROEdge, ROVehicle, SUMOAbstractRouterPermissions<ROEdge, ROVehicle> > AStar;
-                const AStar::LookupTable* lookup = 0;
+                std::shared_ptr<const AStar::LookupTable> lookup;
                 if (oc.isSet("astar.all-distances")) {
-                    lookup = new AStar::FLT(oc.getString("astar.all-distances"), (int)ROEdge::getAllEdges().size());
+                    lookup = std::make_shared<const AStar::FLT>(oc.getString("astar.all-distances"), (int)ROEdge::getAllEdges().size());
                 } else if (oc.isSet("astar.landmark-distances")) {
                     CHRouterWrapper<ROEdge, ROVehicle, SUMOAbstractRouterPermissions<ROEdge, ROVehicle> > router(
                         ROEdge::getAllEdges(), true, &ROEdge::getTravelTimeStatic,
                         begin, end, std::numeric_limits<int>::max(), 1);
                     ROVehicle defaultVehicle(SUMOVehicleParameter(), 0, net.getVehicleTypeSecure(DEFAULT_VTYPE_ID), &net);
-                    lookup = new AStar::LMLT(oc.getString("astar.landmark-distances"), ROEdge::getAllEdges(), &router, &defaultVehicle,
+                    lookup = std::make_shared<const AStar::LMLT>(oc.getString("astar.landmark-distances"), ROEdge::getAllEdges(), &router, &defaultVehicle,
                                              oc.isSet("astar.save-landmark-distances") ? oc.getString("astar.save-landmark-distances") : "", oc.getInt("routing-threads"));
                 }
                 router = new AStar(ROEdge::getAllEdges(), oc.getBool("ignore-errors"), &ROEdge::getTravelTimeStatic, lookup);
             } else {
                 typedef AStarRouter<ROEdge, ROVehicle, SUMOAbstractRouter<ROEdge, ROVehicle> > AStar;
-                const AStar::LookupTable* lookup = 0;
+                std::shared_ptr<const AStar::LookupTable> lookup;
                 if (oc.isSet("astar.all-distances")) {
-                    lookup = new AStar::FLT(oc.getString("astar.all-distances"), (int)ROEdge::getAllEdges().size());
+                    lookup = std::make_shared<const AStar::FLT>(oc.getString("astar.all-distances"), (int)ROEdge::getAllEdges().size());
                 } else if (oc.isSet("astar.landmark-distances")) {
                     CHRouterWrapper<ROEdge, ROVehicle, SUMOAbstractRouter<ROEdge, ROVehicle> > router(
                         ROEdge::getAllEdges(), true, &ROEdge::getTravelTimeStatic,
                         begin, end, std::numeric_limits<int>::max(), 1);
                     ROVehicle defaultVehicle(SUMOVehicleParameter(), 0, net.getVehicleTypeSecure(DEFAULT_VTYPE_ID), &net);
-                    lookup = new AStar::LMLT(oc.getString("astar.landmark-distances"), ROEdge::getAllEdges(), &router, &defaultVehicle,
+                    lookup = std::make_shared<const AStar::LMLT>(oc.getString("astar.landmark-distances"), ROEdge::getAllEdges(), &router, &defaultVehicle,
                                              oc.isSet("astar.save-landmark-distances") ? oc.getString("astar.save-landmark-distances") : "", oc.getInt("routing-threads"));
                 }
                 router = new AStar(ROEdge::getAllEdges(), oc.getBool("ignore-errors"), &ROEdge::getTravelTimeStatic, lookup);

--- a/src/microsim/devices/MSDevice_Routing.cpp
+++ b/src/microsim/devices/MSDevice_Routing.cpp
@@ -390,9 +390,9 @@ MSDevice_Routing::reroute(const SUMOTime currentTime, const bool onInit) {
         } else if (routingAlgorithm == "astar") {
             if (mayHaveRestrictions) {
                 typedef AStarRouter<MSEdge, SUMOVehicle, SUMOAbstractRouterPermissions<MSEdge, SUMOVehicle> > AStar;
-                const AStar::LookupTable* lookup = 0;
+                std::shared_ptr<const AStar::LookupTable> lookup;
                 if (oc.isSet("astar.all-distances")) {
-                    lookup = new AStar::FLT(oc.getString("astar.all-distances"), (int)MSEdge::getAllEdges().size());
+                    lookup = std::make_shared<const AStar::FLT>(oc.getString("astar.all-distances"), (int)MSEdge::getAllEdges().size());
                 } else if (oc.isSet("astar.landmark-distances")) {
                     const double speedFactor = myHolder.getChosenSpeedFactor();
                     // we need an exemplary vehicle with speedFactor 1
@@ -400,15 +400,15 @@ MSDevice_Routing::reroute(const SUMOTime currentTime, const bool onInit) {
                     CHRouterWrapper<MSEdge, SUMOVehicle, SUMOAbstractRouterPermissions<MSEdge, SUMOVehicle> > router(
                         MSEdge::getAllEdges(), true, &MSNet::getTravelTime,
                         string2time(oc.getString("begin")), string2time(oc.getString("end")), std::numeric_limits<int>::max(), 1);
-                    lookup = new AStar::LMLT(oc.getString("astar.landmark-distances"), MSEdge::getAllEdges(), &router, &myHolder, "", oc.getInt("device.rerouting.threads"));
+                    lookup = std::make_shared<AStar::LMLT>(oc.getString("astar.landmark-distances"), MSEdge::getAllEdges(), &router, &myHolder, "", oc.getInt("device.rerouting.threads"));
                     myHolder.setChosenSpeedFactor(speedFactor);
                 }
                 myRouter = new AStar(MSEdge::getAllEdges(), true, &MSDevice_Routing::getEffort, lookup);
             } else {
                 typedef AStarRouter<MSEdge, SUMOVehicle, SUMOAbstractRouter<MSEdge, SUMOVehicle> > AStar;
-                const AStar::LookupTable* lookup = 0;
+                std::shared_ptr<const AStar::LookupTable> lookup;
                 if (oc.isSet("astar.all-distances")) {
-                    lookup = new AStar::FLT(oc.getString("astar.all-distances"), (int)MSEdge::getAllEdges().size());
+                    lookup = std::shared_ptr<const AStar::LookupTable> ( new AStar::FLT(oc.getString("astar.all-distances"), (int)MSEdge::getAllEdges().size()));
                 } else if (oc.isSet("astar.landmark-distances")) {
                     const double speedFactor = myHolder.getChosenSpeedFactor();
                     // we need an exemplary vehicle with speedFactor 1
@@ -416,7 +416,7 @@ MSDevice_Routing::reroute(const SUMOTime currentTime, const bool onInit) {
                     CHRouterWrapper<MSEdge, SUMOVehicle, SUMOAbstractRouter<MSEdge, SUMOVehicle> > router(
                         MSEdge::getAllEdges(), true, &MSNet::getTravelTime,
                         string2time(oc.getString("begin")), string2time(oc.getString("end")), std::numeric_limits<int>::max(), 1);
-                    lookup = new AStar::LMLT(oc.getString("astar.landmark-distances"), MSEdge::getAllEdges(), &router, &myHolder, "", oc.getInt("device.rerouting.threads"));
+                    lookup = std::make_shared<AStar::LMLT>(oc.getString("astar.landmark-distances"), MSEdge::getAllEdges(), &router, &myHolder, "", oc.getInt("device.rerouting.threads"));
                     myHolder.setChosenSpeedFactor(speedFactor);
                 }
                 myRouter = new AStar(MSEdge::getAllEdges(), true, &MSDevice_Routing::getEffort, lookup);

--- a/src/utils/vehicle/AStarRouter.h
+++ b/src/utils/vehicle/AStarRouter.h
@@ -36,6 +36,7 @@
 #include <iterator>
 #include <map>
 #include <iostream>
+#include <memory>
 #include <utils/common/MsgHandler.h>
 #include <utils/common/StringTokenizer.h>
 #include <utils/common/TplConvert.h>
@@ -135,7 +136,7 @@ public:
     };
 
     /// Constructor
-    AStarRouter(const std::vector<E*>& edges, bool unbuildIsWarning, typename BASE::Operation operation, const LookupTable* const lookup = 0) :
+    AStarRouter(const std::vector<E*>& edges, bool unbuildIsWarning, typename BASE::Operation operation, const std::shared_ptr<const LookupTable> lookup = 0) :
         BASE("AStarRouter", operation),
         myErrorMsgHandler(unbuildIsWarning ? MsgHandler::getWarningInstance() : MsgHandler::getErrorInstance()),
         myLookupTable(lookup),
@@ -146,7 +147,7 @@ public:
         }
     }
 
-    AStarRouter(const std::vector<EdgeInfo>& edgeInfos, bool unbuildIsWarning, typename BASE::Operation operation, const LookupTable* const lookup = 0) :
+    AStarRouter(const std::vector<EdgeInfo>& edgeInfos, bool unbuildIsWarning, typename BASE::Operation operation, const std::shared_ptr<const LookupTable> lookup = 0) :
         BASE("AStarRouter", operation),
         myErrorMsgHandler(unbuildIsWarning ? MsgHandler::getWarningInstance() : MsgHandler::getErrorInstance()),
         myLookupTable(lookup),
@@ -340,7 +341,7 @@ protected:
     MsgHandler* const myErrorMsgHandler;
 
     /// @brief the lookup table for travel time heuristics
-    const LookupTable* const myLookupTable;
+    const std::shared_ptr<const LookupTable> myLookupTable;
 
     /// @brief maximum speed in the network
     double myMaxSpeed;


### PR DESCRIPTION
The member variable myLookupTable is a pointer to memory owned by AStarRouter.
However, the memory currently is never freed (#4670, #13). As the AStarRouter can be
[cloned](https://github.com/eclipse/sumo/blob/65b48fbf1c31216e3bb61a839c7b9a36bb952702/src/utils/vehicle/AStarRouter.h#L163), a simple delete in the destructor could lead to use-after-free
errors. I therefore modified myLookupTable to be a shared pointer, which
should allow cloning but free the memory after the last copy/clone of the
router is out of scope.