### PR TITLE
Fix some memory leaks in NLTriggerBuilder (Re #4699)

### DIFF
--- a/src/netload/NLTriggerBuilder.cpp
+++ b/src/netload/NLTriggerBuilder.cpp
@@ -140,6 +140,9 @@ NLTriggerBuilder::parseAndBuildLaneSpeedTrigger(MSNet& net, const SUMOSAXAttribu
         if (file == "") {
             trigger->registerParent(SUMO_TAG_VSS, myHandler);
         }
+        else {
+            delete trigger;
+        }
     } catch (ProcessError& e) {
         throw InvalidArgument(e.what());
     }
@@ -331,10 +334,16 @@ NLTriggerBuilder::parseAndBuildCalibrator(MSNet& net, const SUMOSAXAttributes& a
         if (file == "") {
             trigger->registerParent(SUMO_TAG_CALIBRATOR, myHandler);
         }
+        else {
+            delete trigger;
+        }
     } else {
         MSCalibrator* trigger = buildCalibrator(net, id, edge, lane, pos, file, outfile, freq, probe);
         if (file == "") {
             trigger->registerParent(SUMO_TAG_CALIBRATOR, myHandler);
+        }
+        else {
+            delete trigger;
         }
     }
 }
@@ -381,6 +390,9 @@ NLTriggerBuilder::parseAndBuildRerouter(MSNet& net, const SUMOSAXAttributes& att
         trigger->registerParent(SUMO_TAG_REROUTER, myHandler);
     } else if (!XMLSubSys::runParser(*trigger, file)) {
         throw ProcessError();
+    }
+    else {
+        delete trigger;
     }
 }
 


### PR DESCRIPTION
At several places in the file, memory is allocated and owned by
a pointer named trigger. If the condition "file == "" " is not
fulfilled, a memory leak occurs, as trigger is not deleted. I've added
the appropriate delete calls for these cases.
I suspect that even in the regular case (file==""), the memory also
leaks, as I could not identify any corresponding delete calls in the
parents/owners of trigger (see issue #4699).

Signed-off-by: Sebastian Ehmann <sebastian@dipolmoment.de>