### PR TITLE
Fix null reference in GNELane.cpp

### DIFF
--- a/src/netedit/netelements/GNELane.cpp
+++ b/src/netedit/netelements/GNELane.cpp
@@ -76,7 +76,7 @@ GNELane::GNELane(GNEEdge& edge, const int index) :
 
 GNELane::GNELane() :
     GNENetElement(nullptr, "dummyConstructorGNELane", GLO_LANE, SUMO_TAG_LANE),
-    myParentEdge(*static_cast<GNEEdge*>(0)),
+    myParentEdge(GNEEdge(NBEdge("", nullptr, nullptr, nullptr), nullptr)),
     myIndex(-1),
     mySpecialColor(0) {
 }

--- a/src/netedit/netelements/GNELane.cpp
+++ b/src/netedit/netelements/GNELane.cpp
@@ -62,6 +62,9 @@
 
 // Object implementation
 FXIMPLEMENT(GNELane, FXDelegator, 0, 0)
+//Static GNEEdge for default constructor needed by FOX
+static NBEdge  emptyNBEdge("", nullptr, nullptr, nullptr);
+static GNEEdge emptyGNEEdge(emptyNBEdge, nullptr);
 
 // ===========================================================================
 // method definitions
@@ -76,7 +79,7 @@ GNELane::GNELane(GNEEdge& edge, const int index) :
 
 GNELane::GNELane() :
     GNENetElement(nullptr, "dummyConstructorGNELane", GLO_LANE, SUMO_TAG_LANE),
-    myParentEdge(GNEEdge(NBEdge("", nullptr, nullptr, nullptr), nullptr)),
+    myParentEdge(emptyGNEEdge),
     myIndex(-1),
     mySpecialColor(0) {
 }


### PR DESCRIPTION
Creating a null reference by dereferencing a null pointer is undefined
behaviour. This fix replaces the null reference with a minimal GNEEdge
instance.

Signed-off-by: Sebastian Ehmann <sebastian@dipolmoment.de>