### PR TITLE
Adapt sumolib.net.edge.rebuildShape for crossings and walkingareas missing from/to nodes

### DIFF
--- a/tools/sumolib/net/edge.py
+++ b/tools/sumolib/net/edge.py
@@ -184,11 +184,14 @@ class Edge:
                 self._shape3D.append(
                     (x / float(numLanes), y / float(numLanes), z / float(numLanes)))
 
-        self._shapeWithJunctions3D = addJunctionPos(self._shape3D,
+        if self._function in ["crossing", "walkingarea"]:
+            self._shapeWithJunctions3D = self._shape3D
+            self._rawShape3D = self._shape3D
+        else:
+            self._shapeWithJunctions3D = addJunctionPos(self._shape3D,
                                                     self._from.getCoord3D(), self._to.getCoord3D())
-
-        if self._rawShape3D == []:
-            self._rawShape3D = [self._from.getCoord3D(), self._to.getCoord3D()]
+            if self._rawShape3D == []:
+                self._rawShape3D = [self._from.getCoord3D(), self._to.getCoord3D()]
 
         # 2d - versions
         self._shape = [(x, y) for x, y, z in self._shape3D]


### PR DESCRIPTION
Walkingareas and crossings do not have valid from/to nodes. Referencing them in sumolib.net.edge.rebuildShape leads to an error. That is why the edge function is now checked in sumolib.net.edge.rebuildShape.