### PR TITLE
Properly use DESTDIR, --prefix and --root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,10 +300,11 @@ install(DIRECTORY tools/ DESTINATION share/sumo/tools
         PATTERN "traas" EXCLUDE
         PATTERN "traci4matlab/src" EXCLUDE
         PATTERN ".git" EXCLUDE)
-install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ../../bin $ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/share/sumo/bin)")
-install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/build/setup-sumolib.py clean --all install --prefix $ENV{DESTDIR}${CMAKE_INSTALL_PREFIX})"
+
+install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ../../bin \$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/share/sumo/bin)")
+install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/build/setup-sumolib.py clean --all install --prefix=${CMAKE_INSTALL_PREFIX} --root=\$ENV{DESTDIR} --optimize=1)"
         COMPONENT pysumolib)
-install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/build/setup-traci.py clean --all install --prefix $ENV{DESTDIR}${CMAKE_INSTALL_PREFIX})"
+install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/build/setup-traci.py clean --all install --prefix=${CMAKE_INSTALL_PREFIX} --root=\$ENV{DESTDIR} --optimize=1)"
         COMPONENT pytraci)
 
 string(REPLACE "${SUMO_LIBRARIES}" "" SUMO_LIBRARIES_DLL "${SUMO_LIBRARIES_DLL}")

--- a/src/libsumo/CMakeLists.txt
+++ b/src/libsumo/CMakeLists.txt
@@ -108,8 +108,7 @@ if(SWIG_FOUND)
             else()
                 swig_link_libraries(libsumo -Wl,--whole-archive ${sumolibs} -Wl,--no-whole-archive ${PYTHON_LIBRARIES})
             endif()
-            install(
-                CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/build/setup-libsumo.py clean --all install --prefix $ENV{DESTDIR}${CMAKE_INSTALL_PREFIX})"
+            install(CODE "execute_process(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/tools/build/setup-libsumo.py clean --all install --prefix=${CMAKE_INSTALL_PREFIX} --root=\$ENV{DESTDIR} --optimize=1)"
                 COMPONENT pylibsumo)
         else()
             message(WARNING "ENABLE_PYTHON_BINDINGS is set but python libraries were not found.")


### PR DESCRIPTION
DESTDIR is not properly expanded during the make install phase.
--prefix is separated into --prefix and --root for python.