### PR TITLE
Sumolib: add crossing edges to pedestrian crossings

### DIFF
--- a/tools/sumolib/net/__init__.py
+++ b/tools/sumolib/net/__init__.py
@@ -481,7 +481,7 @@ class NetReader(handler.ContentHandler):
         self._currentEdge = None
         self._currentNode = None
         self._currentLane = None
-        self._crossing2edges = {}
+        self._crossingID2edgeIDs = {}
         self._withPhases = others.get('withPrograms', False)
         self._latestProgram = others.get('withLatestPrograms', False)
         if self._latestProgram:
@@ -516,7 +516,7 @@ class NetReader(handler.ContentHandler):
                 
                 # remember edges crossed by pedestrians to link them later to the crossing objects
                 if function == 'crossing':
-                    self._crossing2edges[edgeID] = attrs.get('crossingEdges').split(' ')
+                    self._crossingID2edgeIDs[edgeID] = attrs.get('crossingEdges').split(' ')
                 
                 self._currentEdge = self._net.addEdge(edgeID, fromNodeID, toNodeID,
                                                       prio, function, attrs.get('name', ''))
@@ -649,7 +649,7 @@ class NetReader(handler.ContentHandler):
 
     def endDocument(self):
         # set crossed edges of pedestrian crossings
-        for crossingID, crossedEdgeIDs in self._crossing2edges.items():
+        for crossingID, crossedEdgeIDs in self._crossingID2edgeIDs.items():
             pedCrossing = self._net.getEdge(crossingID)
             for crossedEdgeID in crossedEdgeIDs:
                 pedCrossing._addCrossingEdge(self._net.getEdge(crossedEdgeID))

--- a/tools/sumolib/net/edge.py
+++ b/tools/sumolib/net/edge.py
@@ -37,6 +37,7 @@ class Edge:
         self._length = None
         self._incoming = {}
         self._outgoing = {}
+        self._crossingEdges = []
         self._shape = None
         self._shapeWithJunctions = None
         self._shape3D = None
@@ -66,12 +67,15 @@ class Edge:
 
     def getTLS(self):
         return self._tls
-
+    
+    def getCrossingEdges(self):
+        return self._crossingEdges
+    
     def addLane(self, lane):
         self._lanes.append(lane)
         self._speed = lane.getSpeed()
         self._length = lane.getLength()
-
+    
     def addOutgoing(self, conn):
         if conn._to not in self._outgoing:
             self._outgoing[conn._to] = []
@@ -81,7 +85,11 @@ class Edge:
         if conn._from not in self._incoming:
             self._incoming[conn._from] = []
         self._incoming[conn._from].append(conn)
-
+    
+    def _addCrossingEdge(self, edge):
+        if edge not in self._crossingEdges:
+            self._crossingEdges.append(edge)
+    
     def setRawShape(self, shape):
         self._rawShape3D = shape
 


### PR DESCRIPTION
Until now, this information was not read from net files when parsing it with sumolib. It may be useful for level of service evaluations (compare green times of motorised traffic with pedestrians).