### PR TITLE
Accept 'all' meta vehicle class in given vector

### DIFF
--- a/src/utils/common/SUMOVehicleClass.cpp
+++ b/src/utils/common/SUMOVehicleClass.cpp
@@ -250,6 +250,9 @@ invertPermissions(SVCPermissions permissions) {
 SVCPermissions
 parseVehicleClasses(const std::vector<std::string>& allowedS) {
     SVCPermissions result = 0;
+	if (std::find(allowedS.begin(), allowedS.end(), "all") != allowedS.end()) {
+		return SVCAll;
+	}
     for (std::vector<std::string>::const_iterator i = allowedS.begin(); i != allowedS.end(); ++i) {
         const SUMOVehicleClass vc = getVehicleClassID(*i);
         const std::string& realName = SumoVehicleClassStrings.getString(vc);


### PR DESCRIPTION
Enables calls from Traci.lane.setAllowed() to open a lane for all vehicle classes without listing them explicitly.
Signed-off-by: m-kro <m.barthauer@t-online.de>