### PR TITLE
Add access to PoI width, height, angle and background image in TraCI 

### DIFF
--- a/src/libsumo/POI.cpp
+++ b/src/libsumo/POI.cpp
@@ -77,6 +77,24 @@ POI::getPosition(const std::string& poiID, const bool includeZ) {
 }
 
 
+double
+POI::getWidth(const std::string& poiID) {
+	return getPoI(poiID)->getWidth();
+}
+
+
+double
+POI::getHeight(const std::string& poiID) {
+	return getPoI(poiID)->getHeight();
+}
+
+
+double
+POI::getAngle(const std::string& poiID) {
+	return getPoI(poiID)->getShapeNaviDegree();
+}
+
+
 std::string
 POI::getParameter(const std::string& poiID, const std::string& key) {
     return getPoI(poiID)->getParameter(key, "");
@@ -100,6 +118,24 @@ POI::setPosition(const std::string& poiID, double x, double y) {
 void
 POI::setColor(const std::string& poiID, const TraCIColor& c) {
     getPoI(poiID)->setShapeColor(Helper::makeRGBColor(c));
+}
+
+
+void
+POI::setWidth(const std::string& poiID, double width) {
+	getPoI(poiID)->setWidth(width);
+}
+
+
+void
+POI::setHeight(const std::string& poiID, double height) {
+	getPoI(poiID)->setHeight(height);
+}
+
+
+void
+POI::setAngle(const std::string& poiID, double angle) {
+	getPoI(poiID)->setShapeNaviDegree(angle);
 }
 
 
@@ -182,6 +218,12 @@ POI::handleVariable(const std::string& objID, const int variable, VariableWrappe
             return wrapper->wrapPosition(objID, variable, getPosition(objID));
         case VAR_POSITION3D:
             return wrapper->wrapPosition(objID, variable, getPosition(objID, true));
+		case VAR_WIDTH:
+			return wrapper->wrapDouble(objID, variable, getWidth(objID));
+		case VAR_HEIGHT:
+			return wrapper->wrapDouble(objID, variable, getHeight(objID));
+		case VAR_ANGLE:
+			return wrapper->wrapDouble(objID, variable, getAngle(objID));
         default:
             return false;
     }

--- a/src/libsumo/POI.cpp
+++ b/src/libsumo/POI.cpp
@@ -104,14 +104,14 @@ POI::setColor(const std::string& poiID, const TraCIColor& c) {
 
 
 bool
-POI::add(const std::string& poiID, double x, double y, const TraCIColor& color, const std::string& poiType, int layer) {
+POI::add(const std::string& poiID, double x, double y, const TraCIColor& color, double width, double height, double angle, const std::string& poiType, const std::string& imgFile, int layer) {
     ShapeContainer& shapeCont = MSNet::getInstance()->getShapeContainer();
     return shapeCont.addPOI(poiID, poiType, Helper::makeRGBColor(color), Position(x, y), false, "", 0, 0, (double)layer,
-                            Shape::DEFAULT_ANGLE,
-                            Shape::DEFAULT_IMG_FILE,
+                            angle,
+                            imgFile,
                             Shape::DEFAULT_RELATIVEPATH,
-                            Shape::DEFAULT_IMG_WIDTH,
-                            Shape::DEFAULT_IMG_HEIGHT);
+                            width,
+                            height);
 }
 
 

--- a/src/libsumo/POI.cpp
+++ b/src/libsumo/POI.cpp
@@ -95,6 +95,12 @@ POI::getAngle(const std::string& poiID) {
 }
 
 
+std::string 
+POI::getImageFile(const std::string& poiID) {
+    return getPoI(poiID)->getShapeImgFile();
+}
+
+
 std::string
 POI::getParameter(const std::string& poiID, const std::string& key) {
     return getPoI(poiID)->getParameter(key, "");
@@ -139,8 +145,14 @@ POI::setAngle(const std::string& poiID, double angle) {
 }
 
 
+void 
+POI::setImageFile(const std::string& poiID, const std::string& imageFile) {
+    getPoI(poiID)->setShapeImgFile(imageFile);
+}
+
+
 bool
-POI::add(const std::string& poiID, double x, double y, const TraCIColor& color, double width, double height, double angle, const std::string& poiType, const std::string& imgFile, int layer) {
+POI::add(const std::string& poiID, double x, double y, const TraCIColor& color, const std::string& poiType, int layer, const std::string& imgFile, double width, double height, double angle) {
     ShapeContainer& shapeCont = MSNet::getInstance()->getShapeContainer();
     return shapeCont.addPOI(poiID, poiType, Helper::makeRGBColor(color), Position(x, y), false, "", 0, 0, (double)layer,
                             angle,
@@ -224,6 +236,8 @@ POI::handleVariable(const std::string& objID, const int variable, VariableWrappe
 			return wrapper->wrapDouble(objID, variable, getHeight(objID));
 		case VAR_ANGLE:
 			return wrapper->wrapDouble(objID, variable, getAngle(objID));
+        case VAR_IMAGFILE:
+            return wrapper->wrapString(objID, variable, getImageFile(objID));
         default:
             return false;
     }

--- a/src/libsumo/POI.h
+++ b/src/libsumo/POI.h
@@ -28,6 +28,7 @@
 
 #include <vector>
 #include <libsumo/TraCIDefs.h>
+#include <utils/shapes/Shape.h>
 
 
 // ===========================================================================
@@ -61,7 +62,7 @@ public:
     static void setType(const std::string& poiID, const std::string& setType);
     static void setColor(const std::string& poiID, const TraCIColor& c);
     static void setPosition(const std::string& poiID, double x, double y);
-    static bool add(const std::string& poiID, double x, double y, const TraCIColor& color, const std::string& poiType = "", int layer = 0);
+	static bool add(const std::string& poiID, double x, double y, const TraCIColor& color, double width = Shape::DEFAULT_IMG_WIDTH, double height = Shape::DEFAULT_IMG_HEIGHT, double angle = Shape::DEFAULT_ANGLE, const std::string& poiType = "", const std::string& imgFile = Shape::DEFAULT_IMG_FILE, int layer = 0);
     static bool remove(const std::string& poiID, int layer = 0);
 
     static void setParameter(const std::string& poiID, const std::string& key, const std::string& value);

--- a/src/libsumo/POI.h
+++ b/src/libsumo/POI.h
@@ -60,6 +60,7 @@ public:
 	static double getWidth(const std::string& poiID);
 	static double getHeight(const std::string& poiID);
 	static double getAngle(const std::string& poiID);
+    static std::string getImageFile(const std::string& poiID);
     static std::string getParameter(const std::string& poiID, const std::string& key);
 
     static void setType(const std::string& poiID, const std::string& setType);
@@ -68,7 +69,8 @@ public:
 	static void setWidth(const std::string& poiID, double width);
 	static void setHeight(const std::string& poiID, double height);
 	static void setAngle(const std::string& poiID, double angle);
-	static bool add(const std::string& poiID, double x, double y, const TraCIColor& color, double width = Shape::DEFAULT_IMG_WIDTH, double height = Shape::DEFAULT_IMG_HEIGHT, double angle = Shape::DEFAULT_ANGLE, const std::string& poiType = "", const std::string& imgFile = Shape::DEFAULT_IMG_FILE, int layer = 0);
+    static void setImageFile(const std::string& poiID, const std::string& imageFile);
+    static bool add(const std::string& poiID, double x, double y, const TraCIColor& color, const std::string& poiType = "", int layer = 0, const std::string& imgFile = Shape::DEFAULT_IMG_FILE, double width = Shape::DEFAULT_IMG_WIDTH, double height = Shape::DEFAULT_IMG_HEIGHT, double angle = Shape::DEFAULT_ANGLE);
     static bool remove(const std::string& poiID, int layer = 0);
 
     static void setParameter(const std::string& poiID, const std::string& key, const std::string& value);

--- a/src/libsumo/POI.h
+++ b/src/libsumo/POI.h
@@ -57,11 +57,17 @@ public:
     static std::string getType(const std::string& poiID);
     static TraCIPosition getPosition(const std::string& poiID, const bool includeZ = false);
     static TraCIColor getColor(const std::string& poiID);
+	static double getWidth(const std::string& poiID);
+	static double getHeight(const std::string& poiID);
+	static double getAngle(const std::string& poiID);
     static std::string getParameter(const std::string& poiID, const std::string& key);
 
     static void setType(const std::string& poiID, const std::string& setType);
     static void setColor(const std::string& poiID, const TraCIColor& c);
     static void setPosition(const std::string& poiID, double x, double y);
+	static void setWidth(const std::string& poiID, double width);
+	static void setHeight(const std::string& poiID, double height);
+	static void setAngle(const std::string& poiID, double angle);
 	static bool add(const std::string& poiID, double x, double y, const TraCIColor& color, double width = Shape::DEFAULT_IMG_WIDTH, double height = Shape::DEFAULT_IMG_HEIGHT, double angle = Shape::DEFAULT_ANGLE, const std::string& poiType = "", const std::string& imgFile = Shape::DEFAULT_IMG_FILE, int layer = 0);
     static bool remove(const std::string& poiID, int layer = 0);
 

--- a/src/traci-server/TraCIConstants.h
+++ b/src/traci-server/TraCIConstants.h
@@ -677,6 +677,9 @@
 // filled? (get: polygons)
 #define VAR_FILL 0x55
 
+// get/set image file (poi, poly, vehicle, person, simulation)
+#define VAR_IMAGFILE 0x93
+
 // position (1D along lane) (get: vehicle)
 #define VAR_LANEPOSITION 0x56
 

--- a/src/traci-server/TraCIConstants.h
+++ b/src/traci-server/TraCIConstants.h
@@ -605,7 +605,7 @@
 // position (3D) (get: vehicle, poi, set: poi)
 #define VAR_POSITION3D 0x39
 
-// angle (get: vehicle)
+// angle (get: vehicle, poi; set: poi)
 #define VAR_ANGLE 0x43
 
 // angle (get: vehicle types, lanes, arealdetector, set: lanes)
@@ -647,7 +647,7 @@
 // minimum gap (get: vehicle types)
 #define VAR_MINGAP 0x4c
 
-// width (get: vehicle types, lanes, polygons)
+// width (get: vehicle types, lanes, polygons, poi)
 #define VAR_WIDTH 0x4d
 
 // shape (get: polygons)
@@ -744,7 +744,7 @@
 // get/set minimum lateral gap (vehicle, vtypes)
 #define VAR_MINGAP_LAT 0xbb
 
-// get/set vehicle height (vehicle, vtypes)
+// get/set vehicle height (vehicle, vtypes, poi)
 #define VAR_HEIGHT 0xbc
 
 // get/set vehicle line

--- a/src/traci-server/TraCIServerAPI_POI.cpp
+++ b/src/traci-server/TraCIServerAPI_POI.cpp
@@ -136,47 +136,67 @@ TraCIServerAPI_POI::processSet(TraCIServer& server, tcpip::Storage& inputStorage
 				libsumo::POI::setAngle(id, angle);
 			}
 			break;
+            case VAR_IMAGFILE: {
+                std::string imageFile;
+                if (!server.readTypeCheckingString(inputStorage, imageFile)) {
+                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The type must be given as a string.", outputStorage);
+                }
+                libsumo::POI::setImageFile(id, imageFile);
+            }
+            break;
             case ADD: {
                 if (inputStorage.readUnsignedByte() != TYPE_COMPOUND) {
                     return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "A compound object is needed for setting a new PoI.", outputStorage);
                 }
                 //read itemNo
-                inputStorage.readInt();
+                const int parameterCount = inputStorage.readInt();
                 std::string type;
                 if (!server.readTypeCheckingString(inputStorage, type)) {
                     return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The first PoI parameter must be the type encoded as a string.", outputStorage);
                 }
-				std::string imgFile;
-				if (!server.readTypeCheckingString(inputStorage, imgFile)) {
-					return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The second PoI parameter must be the imgFile encoded as a string.", outputStorage);
-				}
                 libsumo::TraCIColor col;
                 if (!server.readTypeCheckingColor(inputStorage, col)) {
-                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The third PoI parameter must be the color.", outputStorage);
+                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The second PoI parameter must be the color.", outputStorage);
                 }
                 int layer = 0;
                 if (!server.readTypeCheckingInt(inputStorage, layer)) {
-                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The fourth PoI parameter must be the layer encoded as int.", outputStorage);
+                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The third PoI parameter must be the layer encoded as int.", outputStorage);
                 }
                 libsumo::TraCIPosition pos;
                 if (!server.readTypeCheckingPosition2D(inputStorage, pos)) {
-                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The fifth PoI parameter must be the position.", outputStorage);
+                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The fourth PoI parameter must be the position.", outputStorage);
                 }
-				double width;
-				if (!server.readTypeCheckingDouble(inputStorage, width)) {
-					return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The sixth PoI parameter must be the width.", outputStorage);
-				}
-				double height;
-				if (!server.readTypeCheckingDouble(inputStorage, height)) {
-					return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The seventh PoI parameter must be the height.", outputStorage);
-				}
-				double angle;
-				if (!server.readTypeCheckingDouble(inputStorage, angle)) {
-					return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The eighth PoI parameter must be the angle.", outputStorage);
-				}
-                //
-                if (!libsumo::POI::add(id, pos.x, pos.y, col, width, height, angle, type, imgFile, layer)) {
-                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "Could not add PoI.", outputStorage);
+                if (parameterCount == 4) {
+                    if (!libsumo::POI::add(id, pos.x, pos.y, col, type, layer)) {
+                        return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "Could not add PoI.", outputStorage);
+                    }
+                }
+                else if (parameterCount == 8) {
+                    std::string imgFile;
+                    if (!server.readTypeCheckingString(inputStorage, imgFile)) {
+                        return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The fifth PoI parameter must be the imgFile encoded as a string.", outputStorage);
+                    }
+                    double width;
+                    if (!server.readTypeCheckingDouble(inputStorage, width)) {
+                        return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The sixth PoI parameter must be the width encoded as a double.", outputStorage);
+                    }
+                    double height;
+                    if (!server.readTypeCheckingDouble(inputStorage, height)) {
+                        return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The seventh PoI parameter must be the height encoded as a double.", outputStorage);
+                    }
+                    double angle;
+                    if (!server.readTypeCheckingDouble(inputStorage, angle)) {
+                        return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The eighth PoI parameter must be the angle encoded as a double.", outputStorage);
+                    }
+                    //
+                    if (!libsumo::POI::add(id, pos.x, pos.y, col, type, layer, imgFile, width, height, angle)) {
+                        return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "Could not add PoI.", outputStorage);
+                    }
+                }
+                else {
+                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE,
+                        "Adding a PoI requires either only type, color, layer and position parameters or these and imageFile, width, height and angle parameters.",
+                        outputStorage);
                 }
             }
             break;

--- a/src/traci-server/TraCIServerAPI_POI.cpp
+++ b/src/traci-server/TraCIServerAPI_POI.cpp
@@ -80,6 +80,7 @@ TraCIServerAPI_POI::processSet(TraCIServer& server, tcpip::Storage& inputStorage
 			variable != VAR_WIDTH &&
 			variable != VAR_HEIGHT &&
 			variable != VAR_ANGLE &&
+			variable != VAR_IMAGFILE &&
             variable != ADD &&
             variable != REMOVE &&
             variable != VAR_PARAMETER) {

--- a/src/traci-server/TraCIServerAPI_POI.cpp
+++ b/src/traci-server/TraCIServerAPI_POI.cpp
@@ -77,6 +77,9 @@ TraCIServerAPI_POI::processSet(TraCIServer& server, tcpip::Storage& inputStorage
     if (variable != VAR_TYPE &&
             variable != VAR_COLOR &&
             variable != VAR_POSITION &&
+			variable != VAR_WIDTH &&
+			variable != VAR_HEIGHT &&
+			variable != VAR_ANGLE &&
             variable != ADD &&
             variable != REMOVE &&
             variable != VAR_PARAMETER) {
@@ -104,11 +107,35 @@ TraCIServerAPI_POI::processSet(TraCIServer& server, tcpip::Storage& inputStorage
             case VAR_POSITION: {
                 libsumo::TraCIPosition pos;
                 if (!server.readTypeCheckingPosition2D(inputStorage, pos)) {
-                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The position must be given using an accoring type.", outputStorage);
+                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The position must be given using an according type.", outputStorage);
                 }
                 libsumo::POI::setPosition(id, pos.x, pos.y);
             }
             break;
+			case VAR_WIDTH: {
+				double width;
+				if (!server.readTypeCheckingDouble(inputStorage, width)) {
+					return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The width must be given using an according type.", outputStorage);
+				}
+				libsumo::POI::setWidth(id, width);
+			}
+			break;
+			case VAR_HEIGHT: {
+				double height;
+				if (!server.readTypeCheckingDouble(inputStorage, height)) {
+					return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The height must be given using an according type.", outputStorage);
+				}
+				libsumo::POI::setHeight(id, height);
+			}
+			break;
+			case VAR_ANGLE: {
+				double angle;
+				if (!server.readTypeCheckingDouble(inputStorage, angle)) {
+					return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The angle must be given using an according type.", outputStorage);
+				}
+				libsumo::POI::setAngle(id, angle);
+			}
+			break;
             case ADD: {
                 if (inputStorage.readUnsignedByte() != TYPE_COMPOUND) {
                     return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "A compound object is needed for setting a new PoI.", outputStorage);

--- a/src/traci-server/TraCIServerAPI_POI.cpp
+++ b/src/traci-server/TraCIServerAPI_POI.cpp
@@ -119,20 +119,36 @@ TraCIServerAPI_POI::processSet(TraCIServer& server, tcpip::Storage& inputStorage
                 if (!server.readTypeCheckingString(inputStorage, type)) {
                     return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The first PoI parameter must be the type encoded as a string.", outputStorage);
                 }
+				std::string imgFile;
+				if (!server.readTypeCheckingString(inputStorage, imgFile)) {
+					return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The second PoI parameter must be the imgFile encoded as a string.", outputStorage);
+				}
                 libsumo::TraCIColor col;
                 if (!server.readTypeCheckingColor(inputStorage, col)) {
-                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The second PoI parameter must be the color.", outputStorage);
+                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The third PoI parameter must be the color.", outputStorage);
                 }
                 int layer = 0;
                 if (!server.readTypeCheckingInt(inputStorage, layer)) {
-                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The third PoI parameter must be the layer encoded as int.", outputStorage);
+                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The fourth PoI parameter must be the layer encoded as int.", outputStorage);
                 }
                 libsumo::TraCIPosition pos;
                 if (!server.readTypeCheckingPosition2D(inputStorage, pos)) {
-                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The fourth PoI parameter must be the position.", outputStorage);
+                    return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The fifth PoI parameter must be the position.", outputStorage);
                 }
+				double width;
+				if (!server.readTypeCheckingDouble(inputStorage, width)) {
+					return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The sixth PoI parameter must be the width.", outputStorage);
+				}
+				double height;
+				if (!server.readTypeCheckingDouble(inputStorage, height)) {
+					return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The seventh PoI parameter must be the height.", outputStorage);
+				}
+				double angle;
+				if (!server.readTypeCheckingDouble(inputStorage, angle)) {
+					return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "The eighth PoI parameter must be the angle.", outputStorage);
+				}
                 //
-                if (!libsumo::POI::add(id, pos.x, pos.y, col, type, layer)) {
+                if (!libsumo::POI::add(id, pos.x, pos.y, col, width, height, angle, type, imgFile, layer)) {
                     return server.writeErrorStatusCmd(CMD_SET_POI_VARIABLE, "Could not add PoI.", outputStorage);
                 }
             }

--- a/src/utils/traci/TraCIAPI.cpp
+++ b/src/utils/traci/TraCIAPI.cpp
@@ -1339,7 +1339,7 @@ TraCIAPI::POIScope::setAngle(const std::string& poiID, double angle) const {
 
 
 void
-TraCIAPI::POIScope::add(const std::string& poiID, double x, double y, const libsumo::TraCIColor& c, double width, double height, double angle, const std::string& type, const std::string& imgFile, int layer) const {
+TraCIAPI::POIScope::add(const std::string& poiID, double x, double y, const libsumo::TraCIColor& c, const std::string& type, int layer, const std::string& imgFile, double width, double height, double angle) const {
     tcpip::Storage content;
     content.writeUnsignedByte(TYPE_COMPOUND);
     content.writeInt(4);

--- a/src/utils/traci/TraCIAPI.cpp
+++ b/src/utils/traci/TraCIAPI.cpp
@@ -1258,6 +1258,21 @@ TraCIAPI::POIScope::getColor(const std::string& poiID) const {
     return myParent.getColor(CMD_GET_POI_VARIABLE, VAR_COLOR, poiID);
 }
 
+double 
+TraCIAPI::POIScope::getWidth(const std::string& poiID) const {
+	return myParent.getDouble(CMD_GET_POI_VARIABLE, VAR_WIDTH, poiID);
+}
+
+double 
+TraCIAPI::POIScope::getHeight(const std::string& poiID) const {
+	return myParent.getDouble(CMD_GET_POI_VARIABLE, VAR_HEIGHT, poiID);
+}
+
+double 
+TraCIAPI::POIScope::getAngle(const std::string& poiID) const {
+	return myParent.getDouble(CMD_GET_POI_VARIABLE, VAR_ANGLE, poiID);
+}
+
 
 void
 TraCIAPI::POIScope::setType(const std::string& poiID, const std::string& setType) const {
@@ -1292,13 +1307,46 @@ TraCIAPI::POIScope::setColor(const std::string& poiID, const libsumo::TraCIColor
     myParent.processSet(CMD_SET_POI_VARIABLE);
 }
 
+
+void 
+TraCIAPI::POIScope::setWidth(const std::string& poiID, double width) const {
+	tcpip::Storage content;
+	content.writeUnsignedByte(TYPE_DOUBLE);
+	content.writeDouble(width);
+	myParent.createCommand(CMD_SET_POI_VARIABLE, VAR_WIDTH, poiID, &content);
+	myParent.processSet(CMD_SET_POI_VARIABLE);
+}
+
+
+void 
+TraCIAPI::POIScope::setHeight(const std::string& poiID, double height) const {
+	tcpip::Storage content;
+	content.writeUnsignedByte(TYPE_DOUBLE);
+	content.writeDouble(height);
+	myParent.createCommand(CMD_SET_POI_VARIABLE, VAR_HEIGHT, poiID, &content);
+	myParent.processSet(CMD_SET_POI_VARIABLE);
+}
+
+
+void 
+TraCIAPI::POIScope::setAngle(const std::string& poiID, double angle) const {
+	tcpip::Storage content;
+	content.writeUnsignedByte(TYPE_DOUBLE);
+	content.writeDouble(angle);
+	myParent.createCommand(CMD_SET_POI_VARIABLE, VAR_ANGLE, poiID, &content);
+	myParent.processSet(CMD_SET_POI_VARIABLE);
+}
+
+
 void
-TraCIAPI::POIScope::add(const std::string& poiID, double x, double y, const libsumo::TraCIColor& c, const std::string& type, int layer) const {
+TraCIAPI::POIScope::add(const std::string& poiID, double x, double y, const libsumo::TraCIColor& c, double width, double height, double angle, const std::string& type, const std::string& imgFile, int layer) const {
     tcpip::Storage content;
     content.writeUnsignedByte(TYPE_COMPOUND);
     content.writeInt(4);
     content.writeUnsignedByte(TYPE_STRING);
     content.writeString(type);
+	content.writeUnsignedByte(TYPE_STRING);
+	content.writeString(imgFile);
     content.writeUnsignedByte(TYPE_COLOR);
     content.writeUnsignedByte(c.r);
     content.writeUnsignedByte(c.g);
@@ -1309,6 +1357,12 @@ TraCIAPI::POIScope::add(const std::string& poiID, double x, double y, const libs
     content.writeUnsignedByte(POSITION_2D);
     content.writeDouble(x);
     content.writeDouble(y);
+	content.writeUnsignedByte(TYPE_DOUBLE);
+	content.writeDouble(width);
+	content.writeUnsignedByte(TYPE_DOUBLE);
+	content.writeDouble(height);
+	content.writeUnsignedByte(TYPE_DOUBLE);
+	content.writeDouble(angle);
     myParent.createCommand(CMD_SET_POI_VARIABLE, ADD, poiID, &content);
     myParent.processSet(CMD_SET_POI_VARIABLE);
 }

--- a/src/utils/traci/TraCIAPI.cpp
+++ b/src/utils/traci/TraCIAPI.cpp
@@ -1273,6 +1273,11 @@ TraCIAPI::POIScope::getAngle(const std::string& poiID) const {
 	return myParent.getDouble(CMD_GET_POI_VARIABLE, VAR_ANGLE, poiID);
 }
 
+std::string
+TraCIAPI::POIScope::getImageFile(const std::string& poiID) const {
+    return myParent.getString(CMD_GET_POI_VARIABLE, VAR_IMAGFILE, poiID);
+}
+
 
 void
 TraCIAPI::POIScope::setType(const std::string& poiID, const std::string& setType) const {
@@ -1338,6 +1343,16 @@ TraCIAPI::POIScope::setAngle(const std::string& poiID, double angle) const {
 }
 
 
+void 
+TraCIAPI::POIScope::setImageFile(const std::string& poiID, const std::string& imageFile) const {
+    tcpip::Storage content;
+    content.writeUnsignedByte(TYPE_STRING);
+    content.writeString(imageFile);
+    myParent.createCommand(CMD_SET_POI_VARIABLE, VAR_IMAGFILE, poiID, &content);
+    myParent.processSet(CMD_SET_POI_VARIABLE);
+}
+
+
 void
 TraCIAPI::POIScope::add(const std::string& poiID, double x, double y, const libsumo::TraCIColor& c, const std::string& type, int layer, const std::string& imgFile, double width, double height, double angle) const {
     tcpip::Storage content;
@@ -1345,8 +1360,6 @@ TraCIAPI::POIScope::add(const std::string& poiID, double x, double y, const libs
     content.writeInt(4);
     content.writeUnsignedByte(TYPE_STRING);
     content.writeString(type);
-	content.writeUnsignedByte(TYPE_STRING);
-	content.writeString(imgFile);
     content.writeUnsignedByte(TYPE_COLOR);
     content.writeUnsignedByte(c.r);
     content.writeUnsignedByte(c.g);
@@ -1357,12 +1370,14 @@ TraCIAPI::POIScope::add(const std::string& poiID, double x, double y, const libs
     content.writeUnsignedByte(POSITION_2D);
     content.writeDouble(x);
     content.writeDouble(y);
-	content.writeUnsignedByte(TYPE_DOUBLE);
-	content.writeDouble(width);
-	content.writeUnsignedByte(TYPE_DOUBLE);
-	content.writeDouble(height);
-	content.writeUnsignedByte(TYPE_DOUBLE);
-	content.writeDouble(angle);
+    content.writeUnsignedByte(TYPE_STRING);
+    content.writeString(imgFile);
+    content.writeUnsignedByte(TYPE_DOUBLE);
+    content.writeDouble(width);
+    content.writeUnsignedByte(TYPE_DOUBLE);
+    content.writeDouble(height);
+    content.writeUnsignedByte(TYPE_DOUBLE);
+    content.writeDouble(angle);
     myParent.createCommand(CMD_SET_POI_VARIABLE, ADD, poiID, &content);
     myParent.processSet(CMD_SET_POI_VARIABLE);
 }

--- a/src/utils/traci/TraCIAPI.cpp
+++ b/src/utils/traci/TraCIAPI.cpp
@@ -1357,7 +1357,7 @@ void
 TraCIAPI::POIScope::add(const std::string& poiID, double x, double y, const libsumo::TraCIColor& c, const std::string& type, int layer, const std::string& imgFile, double width, double height, double angle) const {
     tcpip::Storage content;
     content.writeUnsignedByte(TYPE_COMPOUND);
-    content.writeInt(4);
+    content.writeInt(8);
     content.writeUnsignedByte(TYPE_STRING);
     content.writeString(type);
     content.writeUnsignedByte(TYPE_COLOR);

--- a/src/utils/traci/TraCIAPI.h
+++ b/src/utils/traci/TraCIAPI.h
@@ -424,7 +424,7 @@ public:
 		void setWidth(const std::string& poiID, double width) const;
 		void setHeight(const std::string& poiID, double height) const;
 		void setAngle(const std::string& poiID, double angle) const;
-        void add(const std::string& poiID, double x, double y, const libsumo::TraCIColor& c, double width, double height, double angle, const std::string& type, const std::string& imgFile, int layer) const;
+        void add(const std::string& poiID, double x, double y, const libsumo::TraCIColor& c, const std::string& type, int layer, const std::string& imgFile, double width, double height, double angle) const;
         void remove(const std::string& poiID, int layer = 0) const;
 
     private:

--- a/src/utils/traci/TraCIAPI.h
+++ b/src/utils/traci/TraCIAPI.h
@@ -417,6 +417,7 @@ public:
 		double getWidth(const std::string& poiID) const;
 		double getHeight(const std::string& poiID) const;
 		double getAngle(const std::string& poiID) const;
+        std::string getImageFile(const std::string& poiID) const;
 
         void setType(const std::string& poiID, const std::string& setType) const;
         void setPosition(const std::string& poiID, double x, double y) const;
@@ -424,6 +425,7 @@ public:
 		void setWidth(const std::string& poiID, double width) const;
 		void setHeight(const std::string& poiID, double height) const;
 		void setAngle(const std::string& poiID, double angle) const;
+        void setImageFile(const std::string& poiID, const std::string& imageFile) const;
         void add(const std::string& poiID, double x, double y, const libsumo::TraCIColor& c, const std::string& type, int layer, const std::string& imgFile, double width, double height, double angle) const;
         void remove(const std::string& poiID, int layer = 0) const;
 

--- a/src/utils/traci/TraCIAPI.h
+++ b/src/utils/traci/TraCIAPI.h
@@ -414,11 +414,17 @@ public:
         std::string getType(const std::string& poiID) const;
         libsumo::TraCIPosition getPosition(const std::string& poiID) const;
         libsumo::TraCIColor getColor(const std::string& poiID) const;
+		double getWidth(const std::string& poiID) const;
+		double getHeight(const std::string& poiID) const;
+		double getAngle(const std::string& poiID) const;
 
         void setType(const std::string& poiID, const std::string& setType) const;
         void setPosition(const std::string& poiID, double x, double y) const;
         void setColor(const std::string& poiID, const libsumo::TraCIColor& c) const;
-        void add(const std::string& poiID, double x, double y, const libsumo::TraCIColor& c, const std::string& type, int layer) const;
+		void setWidth(const std::string& poiID, double width) const;
+		void setHeight(const std::string& poiID, double height) const;
+		void setAngle(const std::string& poiID, double angle) const;
+        void add(const std::string& poiID, double x, double y, const libsumo::TraCIColor& c, double width, double height, double angle, const std::string& type, const std::string& imgFile, int layer) const;
         void remove(const std::string& poiID, int layer = 0) const;
 
     private:

--- a/tools/traci/_poi.py
+++ b/tools/traci/_poi.py
@@ -87,15 +87,19 @@ class PoiDomain(Domain):
                                                 int(color[3]) if len(color) > 3 else 255)
         self._connection._sendExact()
 
-    def add(self, poiID, x, y, color, poiType="", layer=0):
+    def add(self, poiID, x, y, color, width=1, height=1, angle=0, poiType="", imgFile="", layer=0):
         self._connection._beginMessage(tc.CMD_SET_POI_VARIABLE, tc.ADD, poiID, 1 +
-                                       4 + 1 + 4 + len(poiType) + 1 + 1 + 1 + 1 + 1 + 1 + 4 + 1 + 8 + 8)
+                                       4 + 1 + 4 + len(poiType) + 1 + 4 + len(imgFile) + 1 + 1 + 1 + 1 + 1 + 1 + 4 + 1 + 8 + 8 + 1 + 8 + 1 + 8 + 1 + 8)
         self._connection._string += struct.pack("!Bi", tc.TYPE_COMPOUND, 4)
         self._connection._packString(poiType)
+        self._connection._packString(imgFile)
         self._connection._string += struct.pack("!BBBBB", tc.TYPE_COLOR, int(color[0]), int(color[1]), int(color[2]),
                                                 int(color[3]) if len(color) > 3 else 255)
         self._connection._string += struct.pack("!Bi", tc.TYPE_INTEGER, layer)
         self._connection._string += struct.pack("!Bdd", tc.POSITION_2D, x, y)
+        self._connection._string += struct.pack("!Bd", tc.TYPE_DOUBLE, width)
+        self._connection._string += struct.pack("!Bd", tc.TYPE_DOUBLE, height)
+        self._connection._string += struct.pack("!Bd", tc.TYPE_DOUBLE, angle)
         self._connection._sendExact()
 
     def remove(self, poiID, layer=0):

--- a/tools/traci/_poi.py
+++ b/tools/traci/_poi.py
@@ -23,7 +23,10 @@ _RETURN_VALUE_FUNC = {tc.TRACI_ID_LIST: Storage.readStringList,
                       tc.ID_COUNT: Storage.readInt,
                       tc.VAR_TYPE: Storage.readString,
                       tc.VAR_POSITION: lambda result: result.read("!dd"),
-                      tc.VAR_COLOR: lambda result: result.read("!BBBB")}
+                      tc.VAR_COLOR: lambda result: result.read("!BBBB"),
+                      tc.VAR_WIDTH: Storage.readDouble,
+                      tc.VAR_HEIGHT: Storage.readDouble,
+                      tc.VAR_ANGLE: Storage.readDouble}
 
 
 class PoiDomain(Domain):
@@ -55,6 +58,27 @@ class PoiDomain(Domain):
         """
         return self._getUniversal(tc.VAR_COLOR, poiID)
 
+    def getWidth(self, poiID):
+        """getWidth(string) -> double
+
+        Returns the width of the given poi.
+        """
+        return self._getUniversal(tc.VAR_WIDTH, poiID)
+        
+    def getHeight(self, poiID):
+        """getHeight(string) -> double
+
+        Returns the height of the given poi.
+        """
+        return self._getUniversal(tc.VAR_HEIGHT, poiID)
+        
+    def getAngle(self, poiID):
+        """getAngle(string) -> double
+
+        Returns the angle of the given poi.
+        """
+        return self._getUniversal(tc.VAR_ANGLE, poiID)
+        
     def setType(self, poiID, poiType):
         """setType(string, string) -> None
 
@@ -87,6 +111,36 @@ class PoiDomain(Domain):
                                                 int(color[3]) if len(color) > 3 else 255)
         self._connection._sendExact()
 
+    def setWidth(self, poiID, width):
+        """setWidth(string, double) -> None
+
+        Sets the width of the poi.
+        """
+        self._connection._beginMessage(
+            tc.CMD_SET_POI_VARIABLE, tc.VAR_WIDTH, poiID, 1 + 8)
+        self._connection._string += struct.pack("!Bd", tc.TYPE_DOUBLE, width)
+        self._connection._sendExact()
+
+    def setHeight(self, poiID, height):
+        """setHeight(string, double) -> None
+
+        Sets the height of the poi.
+        """
+        self._connection._beginMessage(
+            tc.CMD_SET_POI_VARIABLE, tc.VAR_HEIGHT, poiID, 1 + 8)
+        self._connection._string += struct.pack("!Bd", tc.TYPE_DOUBLE, height)
+        self._connection._sendExact()
+        
+    def setAngle(self, poiID, angle):
+        """setAngle(string, double) -> None
+
+        Sets the angle of the poi.
+        """
+        self._connection._beginMessage(
+            tc.CMD_SET_POI_VARIABLE, tc.VAR_ANGLE, poiID, 1 + 8)
+        self._connection._string += struct.pack("!Bd", tc.TYPE_DOUBLE, angle)
+        self._connection._sendExact()
+        
     def add(self, poiID, x, y, color, width=1, height=1, angle=0, poiType="", imgFile="", layer=0):
         self._connection._beginMessage(tc.CMD_SET_POI_VARIABLE, tc.ADD, poiID, 1 +
                                        4 + 1 + 4 + len(poiType) + 1 + 4 + len(imgFile) + 1 + 1 + 1 + 1 + 1 + 1 + 4 + 1 + 8 + 8 + 1 + 8 + 1 + 8 + 1 + 8)


### PR DESCRIPTION
- PoI attributes width, height and angle are provided with getter/setter
- In addition to the mentioned attributes, a background image can be specified in traci.poi.add method
- Python and C++ interfaces are adapted to reflect these changes

Would it be possible to reserve a TraCI constant for the background image? Then I would add the corresponding methods, too...