### PR TITLE
Reset errno before possibly writing to it

### DIFF
--- a/src/utils/common/StringUtils.cpp
+++ b/src/utils/common/StringUtils.cpp
@@ -268,6 +268,7 @@ StringUtils::toLong(const std::string& sData) {
         throw EmptyData();
     }
     char* end;
+    errno = 0;
 #ifdef _MSC_VER
     long long int ret = _strtoi64(data, &end, 10);
 #else


### PR DESCRIPTION
This fixes issue #5182 by explicitly setting `errno` to zero before calling the parsing functions.

This is the easiest workaround for the issue, an alternative, which might also reduce complexity, would be to replace the parsing functions with the STL functionality found in e.g. `stringstream`.