### PR TITLE
Now possible to do : traci.simulation.getBusStopWaitingIDList()

### DIFF
--- a/src/libsumo/Simulation.cpp
+++ b/src/libsumo/Simulation.cpp
@@ -270,6 +270,16 @@ Simulation::getBusStopWaiting(const std::string& id) {
     return s->getTransportableNumber();
 }
 
+std::vector<std::string>
+Simulation::getBusStopWaitingIDList(const std::string& id){
+    MSStoppingPlace* s = MSNet::getInstance()->getStoppingPlace(id, SUMO_TAG_BUS_STOP);
+    std::vector<MSTransportable*> transportables = s->getTransportables();
+    std::vector<std::string> result;
+    for(std::vector<MSTransportable*>::iterator it = transportables.begin(); it != transportables.end(); it++){
+        result.push_back((*it)->getID());
+    }
+    return result;
+}
 
 double
 Simulation::getDeltaT() {

--- a/src/libsumo/Simulation.h
+++ b/src/libsumo/Simulation.h
@@ -86,6 +86,10 @@ public:
 
     static int getBusStopWaiting(const std::string& id);
 
+    /** @brief Returns the IDs of the transportables on a given bus stop.
+     */
+    static std::vector<std::string> getBusStopWaitingIDList(const std::string& id);
+
     static double getDeltaT();
 
     static TraCIPositionVector getNetBoundary();

--- a/src/libsumo/TraCIConstants.h
+++ b/src/libsumo/TraCIConstants.h
@@ -802,6 +802,9 @@ TRACI_CONST int VAR_PERSON_NUMBER = 0x67;
 // number of persons waiting at a defined bus stop (get: simulation)
 TRACI_CONST int VAR_BUS_STOP_WAITING = 0x67;
 
+// ids of persons waiting at a defined bus stop (get: simulation)
+TRACI_CONST int VAR_BUS_STOP_WAITING_IDS = 0xef;
+
 // current leader together with gap (get: vehicle)
 TRACI_CONST int VAR_LEADER = 0x68;
 

--- a/src/microsim/MSStoppingPlace.cpp
+++ b/src/microsim/MSStoppingPlace.cpp
@@ -168,6 +168,15 @@ MSStoppingPlace::getStoppingPosition(const SUMOVehicle* veh) const {
     }
 }
 
+std::vector<MSTransportable*>
+MSStoppingPlace::getTransportables() const {
+    std::vector<MSTransportable*> result;
+    for(std::map<MSTransportable*, int>::const_iterator it = myWaitingTransportables.begin(); it!=myWaitingTransportables.end(); it++){
+        result.push_back(it->first);
+    }
+    return result;
+}
+
 bool
 MSStoppingPlace::hasSpaceForTransportable() const {
     return myWaitingSpots.size() > 0;

--- a/src/microsim/MSStoppingPlace.h
+++ b/src/microsim/MSStoppingPlace.h
@@ -160,6 +160,10 @@ public:
         return (int)myWaitingTransportables.size();
     }
 
+    /** @brief Returns the tranportables waiting on this stop
+     */
+    std::vector<MSTransportable*> getTransportables() const;
+
     /** @brief Returns the number of stopped vehicles waiting on this stop
     */
     int getStoppedVehicleNumber() const {

--- a/src/traci-server/TraCIServerAPI_Simulation.cpp
+++ b/src/traci-server/TraCIServerAPI_Simulation.cpp
@@ -138,6 +138,11 @@ TraCIServerAPI_Simulation::processGet(TraCIServer& server, tcpip::Storage& input
                 server.getWrapperStorage().writeUnsignedByte(libsumo::TYPE_INTEGER);
                 server.getWrapperStorage().writeInt(libsumo::Simulation::getBusStopWaiting(id));
                 break;
+
+            case libsumo::VAR_BUS_STOP_WAITING_IDS:
+                server.wrapStringList(id, variable, libsumo::Simulation::getBusStopWaitingIDList(id));
+                break;
+
             case libsumo::VAR_NET_BOUNDING_BOX: {
                 server.getWrapperStorage().writeUnsignedByte(libsumo::TYPE_POLYGON);
                 libsumo::TraCIPositionVector tb = libsumo::Simulation::getNetBoundary();

--- a/tools/traci/_simulation.py
+++ b/tools/traci/_simulation.py
@@ -68,6 +68,7 @@ _RETURN_VALUE_FUNC = {tc.VAR_TIME: Storage.readDouble,
                       tc.VAR_EMERGENCYSTOPPING_VEHICLES_IDS: Storage.readStringList,
                       tc.VAR_MIN_EXPECTED_VEHICLES: Storage.readInt,
                       tc.VAR_BUS_STOP_WAITING: Storage.readInt,
+                      tc.VAR_BUS_STOP_WAITING_IDS: Storage.readStringList,
                       tc.VAR_TELEPORT_STARTING_VEHICLES_NUMBER: Storage.readInt,
                       tc.VAR_TELEPORT_STARTING_VEHICLES_IDS: Storage.readStringList,
                       tc.VAR_TELEPORT_ENDING_VEHICLES_NUMBER: Storage.readInt,
@@ -252,6 +253,12 @@ class SimulationDomain(Domain):
         Get the total number of waiting persons at the named bus stop.
         """
         return self._getUniversal(tc.VAR_BUS_STOP_WAITING, stopID)
+
+    def getBusStopWaitingIDList(self, stopID):
+        """getBusStopWaiting() -> integer
+        Get the IDs of waiting persons at the named bus stop.
+        """
+        return self._getUniversal(tc.VAR_BUS_STOP_WAITING_IDS, stopID)
 
     def getStartingTeleportNumber(self):
         """getStartingTeleportNumber() -> integer

--- a/tools/traci/constants.py
+++ b/tools/traci/constants.py
@@ -783,6 +783,9 @@ VAR_PERSON_NUMBER = 0x67
 #  number of persons waiting at a defined bus stop (get: simulation)
 VAR_BUS_STOP_WAITING = 0x67
 
+#  IDs of persons waiting at a defined bus stop (get: simulation)
+VAR_BUS_STOP_WAITING_IDS = 0xef
+
 #  current leader together with gap (get: vehicle)
 VAR_LEADER = 0x68
 


### PR DESCRIPTION
Hi,
I needed to retrieves the IDs of the persons waiting at a bus stop, so i modified SUMO's and Traci's code to hande that.
I added **VAR_BUS_STOP_WAITING_IDS** to Traci constants (both in c++ and python codes) making sure to make no conflict with existing constants.
I also needed to add the **MSStoppingPlace::getTransportables** and **Simulation::getBusStopWaitingIDList** methods.