### PR TITLE
Now able to do : traci.vehicle[type].getPersonCapacity()

### DIFF
--- a/src/libsumo/Simulation.cpp
+++ b/src/libsumo/Simulation.cpp
@@ -270,6 +270,17 @@ Simulation::getBusStopWaiting(const std::string& id) {
     return s->getTransportableNumber();
 }
 
+std::vector<std::string>
+Simulation::getBusStopWaitingIDList(const std::string& id){
+    MSStoppingPlace* s = MSNet::getInstance()->getStoppingPlace(id, SUMO_TAG_BUS_STOP);
+    std::vector<MSTransportable*> transportables = s->getTransportables();
+    std::vector<std::string> result;
+    for(std::vector<MSTransportable*>::iterator it = transportables.begin(); it != transportables.end(); it++){
+        result.push_back((*it)->getID());
+    }
+    return result;
+}
+
 
 double
 Simulation::getDeltaT() {

--- a/src/libsumo/Simulation.h
+++ b/src/libsumo/Simulation.h
@@ -86,6 +86,11 @@ public:
 
     static int getBusStopWaiting(const std::string& id);
 
+    /** @brief Returns the IDs of the transportables on a given bus stop.
+     */
+    static std::vector<std::string> getBusStopWaitingIDList(const std::string& id);
+
+
     static double getDeltaT();
 
     static TraCIPositionVector getNetBoundary();

--- a/src/libsumo/TraCIConstants.h
+++ b/src/libsumo/TraCIConstants.h
@@ -795,6 +795,9 @@ TRACI_CONST int VAR_NOISEEMISSION = 0x66;
 // current person number (get: vehicle)
 TRACI_CONST int VAR_PERSON_NUMBER = 0x67;
 
+// person capacity (vehicle , vehicle type)
+TRACI_CONST int VAR_PERSON_CAPACITY = 0x38;
+
 // number of persons waiting at a defined bus stop (get: simulation)
 TRACI_CONST int VAR_BUS_STOP_WAITING = 0x67;
 

--- a/src/libsumo/TraCIConstants.h
+++ b/src/libsumo/TraCIConstants.h
@@ -798,6 +798,9 @@ TRACI_CONST int VAR_PERSON_NUMBER = 0x67;
 // number of persons waiting at a defined bus stop (get: simulation)
 TRACI_CONST int VAR_BUS_STOP_WAITING = 0x67;
 
+// ids of persons waiting at a defined bus stop (get: simulation)
+TRACI_CONST int VAR_BUS_STOP_WAITING_IDS = 0xef;
+
 // current leader together with gap (get: vehicle)
 TRACI_CONST int VAR_LEADER = 0x68;
 

--- a/src/libsumo/Vehicle.cpp
+++ b/src/libsumo/Vehicle.cpp
@@ -271,6 +271,11 @@ Vehicle::getPersonNumber(const std::string& vehicleID) {
     return getVehicle(vehicleID)->getPersonNumber();
 }
 
+int
+Vehicle::getPersonCapacity(const std::string& vehicleID) {
+    return getVehicle(vehicleID)->getVehicleType().getPersonCapacity();
+}
+
 std::vector<std::string>
 Vehicle::getPersonIDList(const std::string& vehicleID) {
     return getVehicle(vehicleID)->getPersonIDList();
@@ -1833,6 +1838,8 @@ Vehicle::handleVariable(const std::string& objID, const int variable, VariableWr
             return wrapper->wrapDouble(objID, variable, getElectricityConsumption(objID));
         case VAR_PERSON_NUMBER:
             return wrapper->wrapInt(objID, variable, getPersonNumber(objID));
+        case VAR_PERSON_CAPACITY:
+            return wrapper->wrapInt(objID, variable, getPersonCapacity(objID));
         case LAST_STEP_PERSON_ID_LIST:
             return wrapper->wrapStringList(objID, variable, getPersonIDList(objID));
         case VAR_WAITING_TIME:

--- a/src/libsumo/VehicleType.cpp
+++ b/src/libsumo/VehicleType.cpp
@@ -187,6 +187,10 @@ VehicleType::getParameter(const std::string& typeID, const std::string& key) {
     return getVType(typeID)->getParameter().getParameter(key, "");
 }
 
+int
+VehicleType::getPersonCapacity(const std::string& typeID) {
+    return getVType(typeID)->getPersonCapacity();
+}
 
 void
 VehicleType::setLength(const std::string& typeID, double length)  {
@@ -407,6 +411,8 @@ VehicleType::handleVariable(const std::string& objID, const int variable, Variab
             return wrapper->wrapDouble(objID, variable, getMaxSpeedLat(objID));
         case VAR_LATALIGNMENT:
             return wrapper->wrapString(objID, variable, getLateralAlignment(objID));
+        case VAR_PERSON_CAPACITY:
+            return wrapper->wrapInt(objID, variable, getPersonCapacity(objID));
         default:
             return false;
     }

--- a/src/libsumo/VehicleType.h
+++ b/src/libsumo/VehicleType.h
@@ -48,7 +48,8 @@ static double getHeight(const std::string& typeID); \
 static TraCIColor getColor(const std::string& typeID); \
 static double getMinGapLat(const std::string& typeID); \
 static double getMaxSpeedLat(const std::string& typeID); \
-static std::string getLateralAlignment(const std::string& typeID);
+static std::string getLateralAlignment(const std::string& typeID); \
+static int getPersonCapacity(const std::string& typeID);
 
 #define LIBSUMO_VEHICLE_TYPE_SETTER \
 static void setLength(const std::string& typeID, double length); \

--- a/src/microsim/MSStoppingPlace.cpp
+++ b/src/microsim/MSStoppingPlace.cpp
@@ -168,6 +168,15 @@ MSStoppingPlace::getStoppingPosition(const SUMOVehicle* veh) const {
     }
 }
 
+std::vector<MSTransportable*>
+MSStoppingPlace::getTransportables() const {
+    std::vector<MSTransportable*> result;
+    for(std::map<MSTransportable*, int>::const_iterator it = myWaitingTransportables.begin(); it!=myWaitingTransportables.end(); it++){
+        result.push_back(it->first);
+    }
+    return result;
+}
+
 bool
 MSStoppingPlace::hasSpaceForTransportable() const {
     return myWaitingSpots.size() > 0;

--- a/src/microsim/MSStoppingPlace.h
+++ b/src/microsim/MSStoppingPlace.h
@@ -160,6 +160,10 @@ public:
         return (int)myWaitingTransportables.size();
     }
 
+    /** @brief Returns the tranportables waiting on this stop
+     */
+    std::vector<MSTransportable*> getTransportables() const;
+
     /** @brief Returns the number of stopped vehicles waiting on this stop
     */
     int getStoppedVehicleNumber() const {

--- a/src/traci-server/TraCIServerAPI_Simulation.cpp
+++ b/src/traci-server/TraCIServerAPI_Simulation.cpp
@@ -138,6 +138,9 @@ TraCIServerAPI_Simulation::processGet(TraCIServer& server, tcpip::Storage& input
                 server.getWrapperStorage().writeUnsignedByte(libsumo::TYPE_INTEGER);
                 server.getWrapperStorage().writeInt(libsumo::Simulation::getBusStopWaiting(id));
                 break;
+            case libsumo::VAR_BUS_STOP_WAITING_IDS:
+                server.wrapStringList(id, variable, libsumo::Simulation::getBusStopWaitingIDList(id));
+                break;
             case libsumo::VAR_NET_BOUNDING_BOX: {
                 server.getWrapperStorage().writeUnsignedByte(libsumo::TYPE_POLYGON);
                 libsumo::TraCIPositionVector tb = libsumo::Simulation::getNetBoundary();

--- a/tools/traci/_simulation.py
+++ b/tools/traci/_simulation.py
@@ -68,6 +68,7 @@ _RETURN_VALUE_FUNC = {tc.VAR_TIME: Storage.readDouble,
                       tc.VAR_EMERGENCYSTOPPING_VEHICLES_IDS: Storage.readStringList,
                       tc.VAR_MIN_EXPECTED_VEHICLES: Storage.readInt,
                       tc.VAR_BUS_STOP_WAITING: Storage.readInt,
+                      tc.VAR_BUS_STOP_WAITING_IDS: Storage.readStringList,
                       tc.VAR_TELEPORT_STARTING_VEHICLES_NUMBER: Storage.readInt,
                       tc.VAR_TELEPORT_STARTING_VEHICLES_IDS: Storage.readStringList,
                       tc.VAR_TELEPORT_ENDING_VEHICLES_NUMBER: Storage.readInt,
@@ -252,6 +253,12 @@ class SimulationDomain(Domain):
         Get the total number of waiting persons at the named bus stop.
         """
         return self._getUniversal(tc.VAR_BUS_STOP_WAITING, stopID)
+
+    def getBusStopWaitingIDList(self, stopID):
+        """getBusStopWaiting() -> integer
+        Get the IDs of waiting persons at the named bus stop.
+        """
+        return self._getUniversal(tc.VAR_BUS_STOP_WAITING_IDS, stopID)
 
     def getStartingTeleportNumber(self):
         """getStartingTeleportNumber() -> integer

--- a/tools/traci/_vehicle.py
+++ b/tools/traci/_vehicle.py
@@ -123,6 +123,7 @@ _RETURN_VALUE_FUNC = {tc.VAR_SPEED: Storage.readDouble,
                       tc.VAR_FUELCONSUMPTION: Storage.readDouble,
                       tc.VAR_NOISEEMISSION: Storage.readDouble,
                       tc.VAR_ELECTRICITYCONSUMPTION: Storage.readDouble,
+                      tc.VAR_PERSON_CAPACITY: Storage.readInt,
                       tc.VAR_PERSON_NUMBER: Storage.readInt,
                       tc.LAST_STEP_PERSON_ID_LIST: Storage.readStringList,
                       tc.VAR_EDGE_TRAVELTIME: Storage.readDouble,
@@ -359,6 +360,13 @@ class VehicleDomain(Domain):
         Returns the electricity consumption in Wh for the last time step.
         """
         return self._getUniversal(tc.VAR_ELECTRICITYCONSUMPTION, vehID)
+
+    def getPersonCapacity(self, vehID):
+        """getPersonCapacity(string) -> int
+
+        Returns the Person Capacity of the vehicle
+        """
+        return self._getUniversal(tc.VAR_PERSON_CAPACITY, vehID)
 
     def getPersonNumber(self, vehID):
         """getPersonNumber(string) -> integer

--- a/tools/traci/_vehicletype.py
+++ b/tools/traci/_vehicletype.py
@@ -40,6 +40,7 @@ _RETURN_VALUE_FUNC = {tc.VAR_LENGTH: Storage.readDouble,
                       tc.VAR_MAXSPEED_LAT: Storage.readDouble,
                       tc.VAR_MINGAP_LAT: Storage.readDouble,
                       tc.VAR_LATALIGNMENT: Storage.readString,
+                      tc.VAR_PERSON_CAPACITY: Storage.readInt,
                       tc.VAR_COLOR: lambda result: result.read("!BBBB")}
 
 
@@ -197,6 +198,13 @@ class VehicleTypeDomain(Domain):
         Returns The desired lateral gap of this type at 50km/h in m
         """
         return self._getUniversal(tc.VAR_MINGAP_LAT, vehID)
+
+    def getPersonCapacity(self, typeID):
+        """getPersonCapacity(string) -> int
+
+        Returns the person capacity of this type
+        """
+        return self._getUniversal(tc.VAR_PERSON_CAPACITY, typeID)
 
     def setLength(self, typeID, length):
         """setLength(string, double) -> None

--- a/tools/traci/constants.py
+++ b/tools/traci/constants.py
@@ -779,6 +779,9 @@ VAR_PERSON_NUMBER = 0x67
 #  number of persons waiting at a defined bus stop (get: simulation)
 VAR_BUS_STOP_WAITING = 0x67
 
+#  IDs of persons waiting at a defined bus stop (get: simulation)
+VAR_BUS_STOP_WAITING_IDS = 0xef
+
 #  current leader together with gap (get: vehicle)
 VAR_LEADER = 0x68
 

--- a/tools/traci/constants.py
+++ b/tools/traci/constants.py
@@ -776,6 +776,9 @@ VAR_NOISEEMISSION = 0x66
 #  current person number (get: vehicle)
 VAR_PERSON_NUMBER = 0x67
 
+#  person capacity (get: vehicle, vehicle type)
+VAR_PERSON_CAPACITY = 0x38
+
 #  number of persons waiting at a defined bus stop (get: simulation)
 VAR_BUS_STOP_WAITING = 0x67
 


### PR DESCRIPTION
Hi,
I needed to retrieve the vehicle's capacity using TraCI. So i implemented this functionality.
In order to achieve that, i did the following:

- I added the TraCI constant : ** VAR_PERSON_CAPACITY = 0x38**. I checked, of course, that this value wasn't used before.
- I added the method getPersonCapacity() to both the classes : **libsumo::Vehicle** and **libsumo::VehicleType** and using this methos to hande the ** VAR_PERSON_CAPACITY** requests.
- I added the method **getPersonCapacity()** in both **vehicle** and **vehicleType** domains in TraCI python code.

Regards,
Tarek CHOUAKI.