### PR TITLE
Vehicle::getNextTls() : fixing tls distance.

### DIFF
--- a/src/libsumo/Vehicle.cpp
+++ b/src/libsumo/Vehicle.cpp
@@ -413,13 +413,19 @@ Vehicle::getNextTLS(const std::string& vehicleID) {
             const std::vector<MSLane*>* allowed = prev->allowedLanes(*next, veh->getVClass());
             if (allowed != nullptr && allowed->size() != 0) {
                 for (MSLink* link : allowed->front()->getLinkCont()) {
-                    if (&link->getLane()->getEdge() == next && link->isTLSControlled()) {
-                        TraCINextTLSData ntd;
-                        ntd.id = link->getTLLogic()->getID();
-                        ntd.tlIndex = link->getTLIndex();
-                        ntd.dist = seen;
-                        ntd.state = (char)link->getState();
-                        result.push_back(ntd);
+                    if (&link->getLane()->getEdge() == next) {
+                        // We should add the length of the lane to seen distance
+                        // Whether or not it is controlled by a traffic light
+                        seen += allowed->front()->getLength();
+                        if(link->isTLSControlled())
+                        {
+                            TraCINextTLSData ntd;
+                            ntd.id = link->getTLLogic()->getID();
+                            ntd.tlIndex = link->getTLIndex();
+                            ntd.dist = seen;
+                            ntd.state = (char)link->getState();
+                            result.push_back(ntd);
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
Hi,
I noticed two things when using :

```python
traci.vehicle.getNextTLS(vehicle_id)
```
- If the first next tls is on another edge than the vehicle, the returned distance corresponds to left distance to travel on the current edge.
- In every case, starting from the second TLS, they all have the same distance.

When i took a look into the code, i found that the **seen** variable was incremented only once (for the first edge).
I try here to solve this issue.

Signed-off-by: tarek chouaki <tarek.chouaki@irt-systemx.fr>