### PR TITLE
Added traci.vehicle.getCurrentBusStopID feature

### DIFF
--- a/src/libsumo/TraCIConstants.h
+++ b/src/libsumo/TraCIConstants.h
@@ -741,6 +741,9 @@ TRACI_CONST int MOVE_TO_XY = 0xb4;
 // value = stopped + 2 * parking + 4 * triggered
 TRACI_CONST int VAR_STOPSTATE = 0xb5;
 
+// current bus stop id (get: vehicle)
+TRACI_CONST int VAR_CURRENT_BUS_STOP = 0xcd;
+
 // how lane changing is performed (get/set: vehicle)
 TRACI_CONST int VAR_LANECHANGE_MODE = 0xb6;
 

--- a/src/libsumo/Vehicle.cpp
+++ b/src/libsumo/Vehicle.cpp
@@ -493,6 +493,20 @@ Vehicle::getStopState(const std::string& vehicleID) {
     return result;
 }
 
+std::string
+Vehicle::getCurrentBusStopID(const std::string& vehicleID) {
+    MSVehicle* veh = getVehicle(vehicleID);
+    std::string result = "";
+    if (veh->isOnRoad())
+    {
+        const MSVehicle::Stop& stop = veh->getNextStop();
+        if(stop.busstop != nullptr && stop.reached) {
+            result = stop.busstop->getID();
+        }
+    }
+    return result;
+}
+
 double
 Vehicle::getDistance(const std::string& vehicleID) {
     MSVehicle* veh = getVehicle(vehicleID);
@@ -1857,6 +1871,8 @@ Vehicle::handleVariable(const std::string& objID, const int variable, VariableWr
             return wrapper->wrapInt(objID, variable, getSignals(objID));
         case VAR_STOPSTATE:
             return wrapper->wrapInt(objID, variable, getStopState(objID));
+        case VAR_CURRENT_BUS_STOP:
+            return wrapper->wrapString(objID, variable, getCurrentBusStopID(objID));
         case VAR_DISTANCE:
             return wrapper->wrapDouble(objID, variable, getDistance(objID));
         case VAR_ALLOWED_SPEED:

--- a/src/libsumo/Vehicle.h
+++ b/src/libsumo/Vehicle.h
@@ -94,6 +94,7 @@ public:
     static std::vector<TraCINextTLSData> getNextTLS(const std::string& vehicleID);
     static std::vector<TraCINextStopData> getNextStops(const std::string& vehicleID);
     static int getStopState(const std::string& vehicleID);
+    static std::string getCurrentBusStopID(const std::string& vehicleID);
     static double getDistance(const std::string& vehicleID);
     static double getDrivingDistance(const std::string& vehicleID, const std::string& edgeID, double position, int laneIndex = 0);
     static double getDrivingDistance2D(const std::string& vehicleID, double x, double y);

--- a/tools/traci/_vehicle.py
+++ b/tools/traci/_vehicle.py
@@ -169,6 +169,7 @@ _RETURN_VALUE_FUNC = {tc.VAR_SPEED: Storage.readDouble,
                       tc.DISTANCE_REQUEST: Storage.readDouble,
                       tc.VAR_ROUTING_MODE: Storage.readInt,
                       tc.VAR_STOPSTATE: Storage.readInt,
+                      tc.VAR_CURRENT_BUS_STOP: Storage.readString,
                       tc.VAR_DISTANCE: Storage.readDouble}
 
 
@@ -787,6 +788,14 @@ class VehicleDomain(Domain):
         with each of these flags defined as 0 or 1
         """
         return self._getUniversal(tc.VAR_STOPSTATE, vehID)
+
+    def getCurrentBusStopID(self, vehID):
+        """getCurrentBusStopID(string) -> string
+
+        Returns the ID of the bus stop that the vehicle is currently stopped at.
+        If the vehicle is not stopped at a bus stop, an empty string is returned
+        """
+        return self._getUniversal(tc.VAR_CURRENT_BUS_STOP, vehID)
 
     def isStopped(self, vehID):
         """isStopped(string) -> bool

--- a/tools/traci/constants.py
+++ b/tools/traci/constants.py
@@ -722,6 +722,9 @@ MOVE_TO_XY = 0xb4
 #  value = stopped + 2 * parking + 4 * triggered
 VAR_STOPSTATE = 0xb5
 
+# current bus stop id (get: vehicle)
+VAR_CURRENT_BUS_STOP = 0xcd
+
 #  how lane changing is performed (get/set: vehicle)
 VAR_LANECHANGE_MODE = 0xb6
 


### PR DESCRIPTION
Hi,

I added the possibility to use:

```python
traci.vehicle.getCurrentBusStopID(veh_id) 
```

this allows to retrieve the ID of the current bus stop of a vehicle (when **traci.vehicle.isAtBusStop() returns true**).

Regards.