### PR TITLE
Removing Transportable from Stop at waiting end

### DIFF
--- a/src/microsim/MSTransportable.cpp
+++ b/src/microsim/MSTransportable.cpp
@@ -405,6 +405,11 @@ MSTransportable::Stage_Waiting::proceed(MSNet* net, MSTransportable* transportab
     }
 }
 
+void
+MSTransportable::Stage_Waiting::setArrived(MSNet* net, MSTransportable* transportable, SUMOTime now) {
+    MSTransportable::Stage::setArrived(net, transportable, now);
+    myDestinationStop->removeTransportable(transportable);
+}
 
 void
 MSTransportable::Stage_Waiting::tripInfoOutput(OutputDevice& os, const MSTransportable* const) const {

--- a/src/microsim/MSTransportable.h
+++ b/src/microsim/MSTransportable.h
@@ -372,6 +372,8 @@ public:
         /// proceeds to the next step
         virtual void proceed(MSNet* net, MSTransportable* transportable, SUMOTime now, Stage* previous);
 
+        virtual void setArrived(MSNet* net, MSTransportable* transportable, SUMOTime now);
+
         /** @brief Called on writing tripinfo output
         *
         * @param[in] os The stream to write the information into


### PR DESCRIPTION
Hi,
i noticed that in cases like this:

```xml
<person id="person" depart="0">
        <walk from="1" busStop="busStop1" />
        <ride busStop="busStop3" modes="public" lines="line" />
        <stop busStop="busStop3" duration="30" />
    </person>
```
The person wasn't remove form the busStop at the end of the last stop element. & this would result in a SEGFAULT when trying to do traci.getBusStopWaitingIDList().

Here is a fix to this problem.

Regards.

