### PR TITLE
Minimum duration 0 in osmWebWizard Options panel

### DIFF
--- a/tools/webWizard/index.html
+++ b/tools/webWizard/index.html
@@ -61,7 +61,7 @@
 
                     <div class="options open">
                         <label>Add Polygons <input id="polygons" type="checkbox" checked /></label>
-                        <label>Duration <input id="duration" type="number" value="3600" step="1" /></label>
+                        <label>Duration <input id="duration" type="number" value="3600" min="0" step="1" /></label>
                         <label>Import Public Transport <input id="publicTransport" type="checkbox" /></label>
                         <label>Left Hand Traffic <input id="leftHand" type="checkbox" /></label>
                     </div>


### PR DESCRIPTION
Minimum value for the stepping interval of _"Duration"_ is now **0**.
If a negative number is inserted in _"Duration"_, the _type="number"_ invalidates the entry.

Signed-off-by: Angelo Banse <angelo_22@outlook.com>