### PR TITLE
Ability to retrieve parkingArea's lane id.

### DIFF
--- a/src/libsumo/Simulation.cpp
+++ b/src/libsumo/Simulation.cpp
@@ -631,8 +631,10 @@ Simulation::getParameter(const std::string& objectID, const std::string& key) {
             return toString(pa->getOccupancyIncludingBlocked());
         } else if (attrName == toString(SUMO_ATTR_NAME)) {
             return toString(pa->getMyName());
+        } else if (attrName == "lane") {
+            return pa->getLane().getID();
         } else {
-            throw TraCIException("Invalid parkingArea parameter '" + attrName + "'");
+                throw TraCIException("Invalid parkingArea parameter '" + attrName + "'");
         }
     } else if (StringUtils::startsWith(key, "busStop.")) {
         const std::string attrName = key.substr(8);


### PR DESCRIPTION
Signed-off-by: tarek chouaki <tarek.chouaki@irt-systemx.fr>

Hi,
i added the possibility to retrieve the land where a parkingArea is located. Via the getParameter() method

```python
traci.simulation.getParameter(parking_id, "parkingArea.lane")
```