### PR TITLE
Ability to retrieve chargingStations's lane id.

### DIFF
--- a/src/libsumo/Simulation.cpp
+++ b/src/libsumo/Simulation.cpp
@@ -616,6 +616,8 @@ Simulation::getParameter(const std::string& objectID, const std::string& key) {
             return toString(cs->getTotalCharged());
         } else if (attrName == toString(SUMO_ATTR_NAME)) {
             return toString(cs->getMyName());
+        } else if (attrName == "lane") {
+            return cs->getLane().getID();
         } else {
             throw TraCIException("Invalid chargingStation parameter '" + attrName + "'");
         }


### PR DESCRIPTION
Signed-off-by: tarek chouaki <tarek.chouaki@irt-systemx.fr>

Hi, added the ability to retrieve a chargin station's lane id via traci.

```python
traci.simulation.getParameter(station_id, "chargingStation.lane")
```
Regards.