### PR TITLE
get rid of the hack in MSLane to inform MSCFModel_CC when a collision occurred

### DIFF
--- a/src/microsim/MSLane.cpp
+++ b/src/microsim/MSLane.cpp
@@ -67,7 +67,6 @@
 #include "MSVehicleControl.h"
 #include "MSLeaderInfo.h"
 #include "MSVehicle.h"
-#include "cfmodels/MSCFModel_CC.h"
 
 //#define DEBUG_INSERTION
 //#define DEBUG_PLAN_MOVE
@@ -1585,14 +1584,6 @@ MSLane::handleCollisionBetween(SUMOTime timestep, const std::string& stage, MSVe
         std::swap(collider, victim);
     }
     std::string prefix = "Vehicle '" + collider->getID() + "'; " + collisionType + " with vehicle '" + victim->getID() ;
-    const MSCFModel_CC* model = dynamic_cast<const MSCFModel_CC*>(&collider->getCarFollowModel());
-    if (model) {
-        model->setCrashed(collider, true);
-    }
-    model = dynamic_cast<const MSCFModel_CC*>(&victim->getCarFollowModel());
-    if (model) {
-        model->setCrashed(victim, true, true);
-    }
     if (myCollisionStopTime > 0) {
         if (collider->collisionStopTime() >= 0 && victim->collisionStopTime() >= 0) {
             return;

--- a/src/microsim/cfmodels/CC_VehicleVariables.cpp
+++ b/src/microsim/cfmodels/CC_VehicleVariables.cpp
@@ -48,7 +48,7 @@ CC_VehicleVariables::CC_VehicleVariables() :
     leaderAcceleration(0), leaderControllerAcceleration(0), leaderDataReadTime(0), leaderAngle(0),
     leaderInitialized(false), caccInitialized(false),
     useFixedAcceleration(0), fixedAcceleration(0),
-    crashed(false), crashedVictim(false),
+    crashed(false),
     ccDesiredSpeed(14), ccKp(1), activeController(Plexe::DRIVER),
     nInitialized(0), position(-1), nCars(8),
     caccXi(-1), caccOmegaN(-1), caccC1(-1), caccAlpha1(-1), caccAlpha2(-1),

--- a/src/microsim/cfmodels/CC_VehicleVariables.h
+++ b/src/microsim/cfmodels/CC_VehicleVariables.h
@@ -143,7 +143,6 @@ public:
 
     //car collided in the last timestep
     bool crashed;
-    bool crashedVictim;
 
     /// @brief CC desired speed
     double ccDesiredSpeed;

--- a/src/microsim/cfmodels/MSCFModel_CC.cpp
+++ b/src/microsim/cfmodels/MSCFModel_CC.cpp
@@ -175,6 +175,14 @@ MSCFModel_CC::finalizeSpeed(MSVehicle* const veh, double vPos) const {
     //call processNextStop() to ensure vehicle removal in case of crash
     veh->processNextStop(vPos);
 
+    //check whether the vehicle has collided and set the flag in case
+    if (!vars->crashed) {
+        std::list<MSVehicle::Stop> stops = veh->getMyStops();
+        for (auto s : stops)
+            if (s.collision)
+                vars->crashed = true;
+    }
+
     if (vars->activeController != Plexe::DRIVER) {
         veh->setChosenSpeedFactor(vars->ccDesiredSpeed / veh->getLane()->getSpeedLimit());
     }
@@ -306,7 +314,7 @@ MSCFModel_CC::_v(const MSVehicle* const veh, double gap2pred, double egoSpeed, d
     double time;
     const double currentTime = STEPS2TIME(MSNet::getInstance()->getCurrentTimeStep() + DELTA_T);
 
-    if (vars->crashed || vars->crashedVictim) {
+    if (vars->crashed) {
         return 0;
     }
     if (vars->activeController == Plexe::DRIVER || !vars->useFixedAcceleration) {
@@ -1034,15 +1042,6 @@ void MSCFModel_CC::getRadarMeasurements(const MSVehicle* veh, double& distance, 
         distance = l.second;
         SUMOVehicle* leader = MSNet::getInstance()->getVehicleControl().getVehicle(l.first);
         relativeSpeed = leader->getSpeed() - veh->getSpeed();
-    }
-}
-
-void MSCFModel_CC::setCrashed(const MSVehicle* veh, bool crashed, bool victim) const {
-    CC_VehicleVariables* vars = (CC_VehicleVariables*) veh->getCarFollowVariables();
-    if (victim) {
-        vars->crashedVictim = crashed;
-    } else {
-        vars->crashed = crashed;
     }
 }
 

--- a/src/microsim/cfmodels/MSCFModel_CC.h
+++ b/src/microsim/cfmodels/MSCFModel_CC.h
@@ -243,15 +243,6 @@ public:
     void getRadarMeasurements(const MSVehicle* veh, double& distance, double& relativeSpeed) const;
 
     /**
-     * @brief tells the module that in the last timestep the car has crashed (or not)
-     *
-     * @param[in] veh the vehicle
-     * @param[in] crashed whether the car has crashed or not
-     * @param[in] victim whether the car was the victim or not
-     */
-    void setCrashed(const MSVehicle* veh, bool crashed, bool victim = false) const;
-
-    /**
      * @brief returns the ACC computed acceleration when the faked
      * CACC is controlling the car. This can be used to check for
      * vehicles in front


### PR DESCRIPTION
This commit removes the need of referring to the specific MSCFModel_CC class within the MSLane class to inform the car-following model when a vehicle has collided. The MSCFModel_CC class now automatically queries for stops and checks whether a stop has been caused by a collision.
This change properly works when the parameter `collision.action` is set to `remove` and the parameter `collision.stop` is set to a certain number of seconds.

Signed-off-by: Michele Segata <segata@ccs-labs.org>