### PR TITLE
traci.person.replaceStage(personId, stageIndex, traciStage)

### DIFF
--- a/src/libsumo/Person.cpp
+++ b/src/libsumo/Person.cpp
@@ -536,6 +536,16 @@ Person::appendStage(const TraCIStage& stage, const std::string& personID) {
     p->appendStage(personStage);
 }
 
+void
+Person::replaceStage(const std::string& personID, const int stageIndex, const TraCIStage& stage) {
+    MSTransportable* p = getPerson(personID);
+    if(stageIndex >= p->getNumRemainingStages()) {
+        throw TraCIException("Specified stage index:  is not valid for person " + personID);
+    }
+    MSTransportable::Stage* personStage = convertTraCIStage(stage, personID);
+    p->removeStage(stageIndex);
+    p->appendStage(personStage, stageIndex);
+}
 
 void
 Person::appendDrivingStage(const std::string& personID, const std::string& toEdge, const std::string& lines, const std::string& stopID) {

--- a/src/libsumo/Person.h
+++ b/src/libsumo/Person.h
@@ -72,6 +72,7 @@ public:
 
     static void add(const std::string& personID, const std::string& edgeID, double pos, double depart = DEPARTFLAG_NOW, const std::string typeID = "DEFAULT_PEDTYPE");
     static void appendStage(const TraCIStage& stage, const std::string& personID);
+    static void replaceStage(const std::string& personID, const int stageIndex, const TraCIStage& stage);
     static void appendWaitingStage(const std::string& personID, double duration, const std::string& description = "waiting", const std::string& stopID = "");
     static void appendWalkingStage(const std::string& personID, const std::vector<std::string>& edgeIDs, double arrivalPos, double duration = -1, double speed = -1, const std::string& stopID = "");
     static void appendDrivingStage(const std::string& personID, const std::string& toEdge, const std::string& lines, const std::string& stopID = "");

--- a/src/libsumo/TraCIConstants.h
+++ b/src/libsumo/TraCIConstants.h
@@ -977,6 +977,9 @@ TRACI_CONST int VAR_VEHICLE = 0xc3;
 // append a person stage (person)
 TRACI_CONST int APPEND_STAGE = 0xc4;
 
+// replace a person stage (person)
+TRACI_CONST int REPLACE_STAGE = 0xcd;
+
 // append a person stage (person)
 TRACI_CONST int REMOVE_STAGE = 0xc5;
 

--- a/src/traci-server/TraCIServerAPI_Person.cpp
+++ b/src/traci-server/TraCIServerAPI_Person.cpp
@@ -97,6 +97,7 @@ TraCIServerAPI_Person::processSet(TraCIServer& server, tcpip::Storage& inputStor
     if (variable != libsumo::VAR_PARAMETER
             && variable != libsumo::ADD
             && variable != libsumo::APPEND_STAGE
+            && variable != libsumo::REPLACE_STAGE
             && variable != libsumo::REMOVE_STAGE
             && variable != libsumo::CMD_REROUTE_TRAVELTIME
             && variable != libsumo::MOVE_TO_XY
@@ -259,6 +260,28 @@ TraCIServerAPI_Person::processSet(TraCIServer& server, tcpip::Storage& inputStor
 
             }
             break;
+
+            case libsumo::REPLACE_STAGE : {
+                if (inputStorage.readUnsignedByte() != libsumo::TYPE_COMPOUND) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_PERSON_VARIABLE, "Replacing a person stage requires a compound object.", outputStorage);
+                }
+                if (inputStorage.readInt() != 2) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_PERSON_VARIABLE, "Replacing a person stage requires a compound object of size 2.", outputStorage);
+                }
+                int nextStageIndex = 0;
+                if(!server.readTypeCheckingInt(inputStorage, nextStageIndex)) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_PERSON_VARIABLE, "First parameter of replace stage should be an integer", outputStorage);
+                }
+                if (inputStorage.readUnsignedByte() != libsumo::TYPE_COMPOUND) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_PERSON_VARIABLE, "Second parameter of replace stage should be a compound object", outputStorage);
+                }
+                if (inputStorage.readInt() != 13) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_PERSON_VARIABLE, "Second parameter of replace stage should be a compound object of size 13", outputStorage);
+                }
+                libsumo::Person::replaceStage(id, nextStageIndex, *TraCIServerAPI_Simulation::readStage(server, inputStorage));
+            }
+            break;
+
             case libsumo::REMOVE_STAGE: {
                 int nextStageIndex = 0;
                 if (!server.readTypeCheckingInt(inputStorage, nextStageIndex)) {

--- a/tools/traci/_person.py
+++ b/tools/traci/_person.py
@@ -281,6 +281,13 @@ class PersonDomain(Domain):
         simulation._writeStage(stage, self._connection)
         self._connection._sendExact()
 
+    def replaceStage(self, personID, stageIndex, stage):
+        self._connection._beginMessage(tc.CMD_SET_PERSON_VARIABLE, tc.REPLACE_STAGE, personID, simulation._stageSize(stage))
+        self._connection._string += struct.pack("!Bi", tc.TYPE_COMPOUND, 2)
+        self._connection._string += struct.pack("!Bi", tc.TYPE_INTEGER, stageIndex)
+        simulation._writeStage(stage, self._connection)
+        self._connection._sendExact()
+
     def appendDrivingStage(self, personID, toEdge, lines, stopID=""):
         """appendDrivingStage(string, string, string, string)
         Appends a driving stage to the plan of the given person

--- a/tools/traci/_simulation.py
+++ b/tools/traci/_simulation.py
@@ -65,7 +65,6 @@ def _stageSize(stage):
 
 
 def _writeStage(stage, connection):
-    assert(isinstance(stage, Stage))
     connection._string += struct.pack("!Bi", tc.TYPE_COMPOUND, 13)
     connection._string += struct.pack("!Bi", tc.TYPE_INTEGER, stage.type)
     connection._packString(stage.vType)

--- a/tools/traci/constants.py
+++ b/tools/traci/constants.py
@@ -958,6 +958,9 @@ VAR_VEHICLE = 0xc3
 #  append a person stage (person)
 APPEND_STAGE = 0xc4
 
+# replace a person stage (person)
+REPLACE_STAGE = 0xcd
+
 #  append a person stage (person)
 REMOVE_STAGE = 0xc5
 


### PR DESCRIPTION
Hi,
i added the ability to do :

```python
traci.person.replaceStage(personID, stageIndex, traciStage
```

For future modifications, i'd like to replace the namedtuple Stage with a proper class (because a named tuple is not mutable). Is this okey ?

Signed-off-by: tarek chouaki <tarek.chouaki@irt-systemx.fr>