### PR TITLE
Float zero comparison in CFM arrival estimation

### DIFF
--- a/src/microsim/cfmodels/MSCFModel.cpp
+++ b/src/microsim/cfmodels/MSCFModel.cpp
@@ -390,7 +390,7 @@ MSCFModel::estimateArrivalTime(double dist, double speed, double maxSpeed, doubl
     assert(speed >= 0.);
     assert(dist >= 0.);
 
-    if (dist == 0.) {
+    if (dist < NUMERICAL_EPS) {
         return 0.;
     }
 
@@ -399,7 +399,7 @@ MSCFModel::estimateArrivalTime(double dist, double speed, double maxSpeed, doubl
         return INVALID_DOUBLE;
     }
 
-    if (accel == 0.) {
+    if (fabs(accel) < NUMERICAL_EPS) {
         return dist / speed;
     }
 


### PR DESCRIPTION
Replaces the direct floating point comparison to 0 inside the CFM arrival estimation with a check against NUMERICAL_EPS.
Signed-off-by: m-kro <m.barthauer@t-online.de>