### PR TITLE
remove pointer usage in SUMOSAXReader, fix #5871

### DIFF
--- a/src/utils/xml/SUMOSAXReader.cpp
+++ b/src/utils/xml/SUMOSAXReader.cpp
@@ -24,6 +24,7 @@
 #include <config.h>
 
 #include <string>
+#include <memory>
 #include <iostream>
 #include <xercesc/sax2/XMLReaderFactory.hpp>
 #include <xercesc/framework/LocalFileInputSource.hpp>
@@ -158,8 +159,8 @@ SUMOSAXReader::parseFirst(std::string systemID) {
         }
         myToken = XERCES_CPP_NAMESPACE::XMLPScanToken();
 #ifdef HAVE_ZLIB
-        myIStream = new zstr::ifstream(systemID.c_str(), std::fstream::in | std::fstream::binary);
-        myInputStream = new IStreamInputSource(*myIStream);
+        myIStream = std::unique_ptr<zstr::ifstream>(new zstr::ifstream(systemID.c_str(), std::fstream::in | std::fstream::binary));
+        myInputStream = std::unique_ptr<IStreamInputSource>(new IStreamInputSource(*myIStream));
         return myXMLReader->parseFirst(*myInputStream, myToken);
 #else
         return myXMLReader->parseFirst(systemID.c_str(), myToken);

--- a/src/utils/xml/SUMOSAXReader.h
+++ b/src/utils/xml/SUMOSAXReader.h
@@ -26,6 +26,7 @@
 #include <config.h>
 
 #include <string>
+#include <memory>
 #include <vector>
 #include <xercesc/sax2/SAX2XMLReader.hpp>
 #include <xercesc/sax/EntityResolver.hpp>
@@ -116,9 +117,9 @@ private:
 
     BinaryInputDevice* myBinaryInput;
 
-    std::istream* myIStream;
+    std::unique_ptr<std::istream> myIStream;
 
-    IStreamInputSource* myInputStream;
+    std::unique_ptr<IStreamInputSource> myInputStream;
 
     char mySbxVersion;
 


### PR DESCRIPTION
This PR should fix the file descriptor leak described [here](https://github.com/eclipse/sumo/issues/5871).

I just replaced the usage of the raw pointers in the parseFirst method and use shared pointer instead, which will clean up the file handle by default.

I don't see a reason for using raw pointers here.
I also removed them as members of the class as they are not needed as well. The fields are never used and can't be used for later clean up in the destructor as parseFirst is public and could be called multiple times.