### PR TITLE
replace raw pointer with unique_ptr in SUMOSAXReader

### DIFF
--- a/src/utils/xml/SUMOSAXReader.cpp
+++ b/src/utils/xml/SUMOSAXReader.cpp
@@ -24,6 +24,7 @@
 #include <config.h>
 
 #include <string>
+#include <memory>
 #include <iostream>
 #include <xercesc/sax2/XMLReaderFactory.hpp>
 #include <xercesc/framework/LocalFileInputSource.hpp>
@@ -158,8 +159,8 @@ SUMOSAXReader::parseFirst(std::string systemID) {
         }
         myToken = XERCES_CPP_NAMESPACE::XMLPScanToken();
 #ifdef HAVE_ZLIB
-        myIStream = new zstr::ifstream(systemID.c_str(), std::fstream::in | std::fstream::binary);
-        myInputStream = new IStreamInputSource(*myIStream);
+        myIStream = std::unique_ptr<zstr::ifstream>(new zstr::ifstream(systemID.c_str(), std::fstream::in | std::fstream::binary));
+        myInputStream = std::unique_ptr<IStreamInputSource>(new IStreamInputSource(*myIStream));
         return myXMLReader->parseFirst(*myInputStream, myToken);
 #else
         return myXMLReader->parseFirst(systemID.c_str(), myToken);

--- a/src/utils/xml/SUMOSAXReader.h
+++ b/src/utils/xml/SUMOSAXReader.h
@@ -26,6 +26,7 @@
 #include <config.h>
 
 #include <string>
+#include <memory>
 #include <vector>
 #include <xercesc/sax2/SAX2XMLReader.hpp>
 #include <xercesc/sax/EntityResolver.hpp>
@@ -116,9 +117,9 @@ private:
 
     BinaryInputDevice* myBinaryInput;
 
-    std::istream* myIStream;
+    std::unique_ptr<std::istream> myIStream;
 
-    IStreamInputSource* myInputStream;
+    std::unique_ptr<IStreamInputSource> myInputStream;
 
     char mySbxVersion;
 


### PR DESCRIPTION
new PR to replace the one with the broken sign-off

fixe file handle leak in SUMOSAXReader by replacing raw pointers with unique pointers.

Signed-off-by: Tobias Jacobowitz <tobias.jacobowitz@posteo.de>