### PR TITLE
SSM device: cover test ticket5231

### DIFF
--- a/src/microsim/devices/MSDevice_SSM.h
+++ b/src/microsim/devices/MSDevice_SSM.h
@@ -421,7 +421,7 @@ public:
 
     /** @brief Collects all vehicles within range 'range' upstream of the position 'pos' on the edge 'edge' into foeCollector
      */
-    static void getUpstreamVehicles(const UpstreamScanStartInfo& scanStart, FoeInfoMap& foeCollector, std::set<const MSLane*>& seenLanes);
+    static void getUpstreamVehicles(const UpstreamScanStartInfo& scanStart, FoeInfoMap& foeCollector, std::set<const MSLane*>& seenLanes, const std::set<const MSJunction*>& routeJunctions);
 
     /** @brief Collects all vehicles on the junction into foeCollector
      */


### PR DESCRIPTION
The SSM scan order introduced in #6009 could not cover the test belonging to ticket5231 due to the order and the stop criteria of the upstream search. The upstream search  could reach an edge on the ego route along a different path but still stop before the downstream range, meaning the lanes are marked as checked but vehicles in downstream range are not found.
In this pull request, it is checked whether the upstream search reaches the junctions of the ego route and stops there. This is still not perfect as it might have a remaining range but at least fulfills ticket5231 test.

Signed-off-by: m-kro <m.barthauer@t-online.de>