### PR TITLE
Fixes the traci variable value for crashed vehicles in the CC car-following model

### DIFF
--- a/src/microsim/cfmodels/MSCFModel_CC.cpp
+++ b/src/microsim/cfmodels/MSCFModel_CC.cpp
@@ -177,13 +177,10 @@ MSCFModel_CC::finalizeSpeed(MSVehicle* const veh, double vPos) const {
 
     //check whether the vehicle has collided and set the flag in case
     if (!vars->crashed) {
-        std::list<MSVehicle::Stop> stops = veh->getMyStops();
-        for (auto s : stops)
-            if (s.collision) {
-                vars->crashed = true;
-            }
+    	if(MSNet::getInstance()->getVehicleControl().getCollisionCount()>0) {
+             vars->crashed = true;
+	}
     }
-
     if (vars->activeController != Plexe::DRIVER) {
         veh->setChosenSpeedFactor(vars->ccDesiredSpeed / veh->getLane()->getSpeedLimit());
     }


### PR DESCRIPTION
The CC car following model for Veins-Plexe (Platooning) previously used the "getMyStops()" method to check if a vehicle cause a collision. 

This pull request changes the mechanism by considering the amount of collisions for a vehicle. If a vehicle has a `collsionCount>0` the according variable is set to true