### PR TITLE
Minor doc change

### DIFF
--- a/docs/web/docs/Simulation/Output/Traffic_Lights.md
+++ b/docs/web/docs/Simulation/Output/Traffic_Lights.md
@@ -35,7 +35,7 @@ The output looks like this:
 </tlsStates>
 ```
 
-The state is saved in each simulation second. The state itself is coded
+The state is saved in each simulation step. The state itself is coded
 as a list of the characters 'G', 'Y', and 'R', standing for "green",
 "yellow", and "red", respectively, see [Simulation/Traffic
 Lights](../../Simulation/Traffic_Lights.md). Each character describes


### PR DESCRIPTION
TLS output is not bound to simulation seconds, but to the simulation step length.
Signed-off-by: m-kro <m.barthauer@t-online.de>