### PR TITLE
Respect internal lane permissions for best lanes selection

### DIFF
--- a/src/microsim/MSEdge.cpp
+++ b/src/microsim/MSEdge.cpp
@@ -344,7 +344,7 @@ MSEdge::rebuildAllowedTargets(const bool updateVehicles) {
                     for (MSLane* const lane : *myLanes) {
                         if (lane->allowsVehicleClass((SUMOVehicleClass)vclass)) {
                             for (const MSLink* const link : lane->getLinkCont()) {
-                                if (link->getLane()->allowsVehicleClass((SUMOVehicleClass)vclass) && &link->getLane()->getEdge() == target) {
+                                if (link->getLane()->allowsVehicleClass((SUMOVehicleClass)vclass) && &link->getLane()->getEdge() == target && (link->getViaLane() == nullptr || link->getViaLane()->allowsVehicleClass((SUMOVehicleClass)vclass))) {
                                     allowedLanes->push_back(lane);
                                 }
                             }


### PR DESCRIPTION
Currently, internal lanes can be opened or closed for certain vehicle classes (e.g. using TraCI commands, but not in Netedit), but this is not taken into account for vehicle routing and lane selection. Only lane permissions outside of intersections are respected.
With this additional check, internal lane permissions are used, too, to determine the lane of a vehicle along its route. This can be useful for implementing dynamic lane assignment at intersections, e.g. to forbid left-turns during peak hour. 

Signed-off-by: m-kro <m.barthauer@t-online.de>