### PR TITLE
SSM device: check for invalid arrival times

### DIFF
--- a/src/microsim/devices/MSDevice_SSM.cpp
+++ b/src/microsim/devices/MSDevice_SSM.cpp
@@ -1288,7 +1288,7 @@ MSDevice_SSM::determineTTCandDRAC(EncounterApproachInfo& eInfo) const {
         if (myComputeDRAC) {
             drac = computeDRAC(eInfo);
         }
-        if (eInfo.egoEstimatedConflictEntryTime <= eInfo.foeEstimatedConflictExitTime) {
+        if (eInfo.egoEstimatedConflictEntryTime <= eInfo.foeEstimatedConflictExitTime && eInfo.foeEstimatedConflictExitTime < INVALID) {
             // follower's predicted arrival at the crossing area is earlier than the leader's predicted exit -> collision predicted
             double gap = eInfo.egoConflictEntryDist;
             if (myComputeTTC) {
@@ -1303,7 +1303,7 @@ MSDevice_SSM::determineTTCandDRAC(EncounterApproachInfo& eInfo) const {
         if (myComputeDRAC) {
             drac = computeDRAC(eInfo);
         }
-        if (eInfo.foeEstimatedConflictEntryTime <= eInfo.egoEstimatedConflictExitTime) {
+        if (eInfo.foeEstimatedConflictEntryTime <= eInfo.egoEstimatedConflictExitTime && eInfo.egoEstimatedConflictExitTime < INVALID) {
             // follower's predicted arrival at the crossing area is earlier than the leader's predicted exit -> collision predicted
             double gap = eInfo.foeConflictEntryDist;
             if (myComputeTTC) {


### PR DESCRIPTION
Related to general topic #5527 .
For crossing conflicts, the TTC measure takes into account the estimated arrival and exit times of the vehicles in the conflict area. When a vehicle is at standstill, the function used for the time estimation returns INVALID_DOUBLE. Now this is checked before it leads to unreasonable TTC values.

Signed-off-by: m-kro <m.barthauer@t-online.de>