### PR TITLE
avoid warning at compile time

### DIFF
--- a/src/microsim/cfmodels/MSCFModel_CC.cpp
+++ b/src/microsim/cfmodels/MSCFModel_CC.cpp
@@ -178,7 +178,7 @@ MSCFModel_CC::finalizeSpeed(MSVehicle* const veh, double vPos) const {
     //check whether the vehicle has collided and set the flag in case
     if (!vars->crashed) {
         std::list<MSVehicle::Stop> stops = veh->getMyStops();
-        for (auto s : stops)
+        for (auto& s : stops)
             if (s.collision) {
                 vars->crashed = true;
             }


### PR DESCRIPTION
Otherwise, the following warning is thrown:
implicitly-declared ‘MSVehicle::Stop::Stop(const MSVehicle::Stop&)’ is deprecated [-Wdeprecated-copy]