### PR TITLE
Define internal lane permissions

### DIFF
--- a/data/xsd/connections_file.xsd
+++ b/data/xsd/connections_file.xsd
@@ -35,6 +35,8 @@
         <xsd:attribute name="keepClear" type="boolType" use="optional"/>
         <xsd:attribute name="contPos" type="xsd:float" use="optional"/>
         <xsd:attribute name="visibility" type="xsd:float" use="optional"/>
+        <xsd:attribute name="allow" type="xsd:string" use="optional"/>
+        <xsd:attribute name="disallow" type="xsd:string" use="optional"/>
         <xsd:attribute name="speed" type="xsd:float" use="optional"/>
         <xsd:attribute name="shape" type="shapeType" use="optional"/>
     </xsd:complexType>

--- a/data/xsd/net_file.xsd
+++ b/data/xsd/net_file.xsd
@@ -200,6 +200,8 @@
         <xsd:attribute name="keepClear" type="boolType" use="optional"/>
         <xsd:attribute name="contPos" type="xsd:float" use="optional"/>
         <xsd:attribute name="visibility" type="xsd:float" use="optional"/>
+        <xsd:attribute name="allow" type="xsd:string" use="optional"/>
+        <xsd:attribute name="disallow" type="xsd:string" use="optional"/>
         <xsd:attribute name="speed" type="xsd:float" use="optional"/>
         <xsd:attribute name="shape" type="shapeType" use="optional"/>
         <xsd:attribute name="uncontrolled" type="boolType" use="optional"/>

--- a/src/netbuild/NBEdge.cpp
+++ b/src/netbuild/NBEdge.cpp
@@ -99,6 +99,7 @@ NBEdge::Connection::Connection(int fromLane_, NBEdge* toEdge_, int toLane_) :
     keepClear(true),
     contPos(UNSPECIFIED_CONTPOS),
     visibility(UNSPECIFIED_VISIBILITY_DISTANCE),
+    permissions(SVC_UNSPECIFIED),
     speed(UNSPECIFIED_SPEED),
     id(toEdge_ == nullptr ? "" : toEdge->getFromNode()->getID()),
     haveVia(false),
@@ -108,7 +109,7 @@ NBEdge::Connection::Connection(int fromLane_, NBEdge* toEdge_, int toLane_) :
 
 
 NBEdge::Connection::Connection(int fromLane_, NBEdge* toEdge_, int toLane_, bool mayDefinitelyPass_, bool keepClear_, double contPos_,
-                               double visibility_, double speed_, bool haveVia_, bool uncontrolled_, const PositionVector& customShape_) :
+                               double visibility_, double speed_, bool haveVia_, bool uncontrolled_, const PositionVector& customShape_, SVCPermissions permissions_) :
     fromLane(fromLane_),
     toEdge(toEdge_),
     toLane(toLane_),
@@ -123,7 +124,8 @@ NBEdge::Connection::Connection(int fromLane_, NBEdge* toEdge_, int toLane_, bool
     vmax(UNSPECIFIED_SPEED),
     haveVia(haveVia_),
     internalLaneIndex(UNSPECIFIED_INTERNAL_LANE_INDEX),
-    uncontrolled(uncontrolled_) {
+    uncontrolled(uncontrolled_),
+    permissions(permissions_) {
 }
 
 
@@ -980,7 +982,8 @@ NBEdge::addLane2LaneConnection(int from, NBEdge* dest,
                                double visibility,
                                double speed,
                                const PositionVector& customShape,
-                               bool uncontrolled) {
+                               bool uncontrolled,
+                               SVCPermissions permissions) {
     if (myStep == EdgeBuildingStep::INIT_REJECT_CONNECTIONS) {
         return true;
     }
@@ -993,7 +996,7 @@ NBEdge::addLane2LaneConnection(int from, NBEdge* dest,
     if (!addEdge2EdgeConnection(dest)) {
         return false;
     }
-    return setConnection(from, dest, toLane, type, mayUseSameDestination, mayDefinitelyPass, keepClear, contPos, visibility, speed, customShape, uncontrolled);
+    return setConnection(from, dest, toLane, type, mayUseSameDestination, mayDefinitelyPass, keepClear, contPos, visibility, speed, customShape, uncontrolled, permissions);
 }
 
 
@@ -1024,7 +1027,8 @@ NBEdge::setConnection(int lane, NBEdge* destEdge,
                       double visibility,
                       double speed,
                       const PositionVector& customShape,
-                      bool uncontrolled) {
+                      bool uncontrolled,
+                      SVCPermissions permissions) {
     if (myStep == EdgeBuildingStep::INIT_REJECT_CONNECTIONS) {
         return false;
     }
@@ -1062,6 +1066,7 @@ NBEdge::setConnection(int lane, NBEdge* destEdge,
     myConnections.back().keepClear = keepClear;
     myConnections.back().contPos = contPos;
     myConnections.back().visibility = visibility;
+    myConnections.back().permissions = permissions;
     myConnections.back().speed = speed;
     myConnections.back().customShape = customShape;
     myConnections.back().uncontrolled = uncontrolled;

--- a/src/netbuild/NBEdge.h
+++ b/src/netbuild/NBEdge.h
@@ -203,7 +203,8 @@ public:
                    double speed_ = UNSPECIFIED_SPEED,
                    bool haveVia_ = false,
                    bool uncontrolled_ = false,
-                   const PositionVector& customShape_ = PositionVector::EMPTY);
+                   const PositionVector& customShape_ = PositionVector::EMPTY,
+                   SVCPermissions permissions = SVC_UNSPECIFIED);
 
         /// @brief The lane the connections starts at
         int fromLane;
@@ -231,6 +232,9 @@ public:
 
         /// @brief custom foe visiblity for connection
         double visibility;
+
+        /// @brief List of vehicle types that are allowed on this connection
+        SVCPermissions permissions;
 
         /// @brief custom speed for connection
         double speed;
@@ -832,7 +836,8 @@ public:
                                 double visibility = UNSPECIFIED_VISIBILITY_DISTANCE,
                                 double speed = UNSPECIFIED_SPEED,
                                 const PositionVector& customShape = PositionVector::EMPTY,
-                                const bool uncontrolled = UNSPECIFIED_CONNECTION_UNCONTROLLED);
+                                const bool uncontrolled = UNSPECIFIED_CONNECTION_UNCONTROLLED,
+                                SVCPermissions = SVC_UNSPECIFIED);
 
     /** @brief Builds no connections starting at the given lanes
      *
@@ -876,7 +881,8 @@ public:
                        double visibility = UNSPECIFIED_VISIBILITY_DISTANCE,
                        double speed = UNSPECIFIED_SPEED,
                        const PositionVector& customShape = PositionVector::EMPTY,
-                       const bool uncontrolled = UNSPECIFIED_CONNECTION_UNCONTROLLED);
+                       const bool uncontrolled = UNSPECIFIED_CONNECTION_UNCONTROLLED,
+                       SVCPermissions permissions = SVC_UNSPECIFIED);
 
     /** @brief Returns connections from a given lane
      *

--- a/src/netbuild/NBEdgeCont.cpp
+++ b/src/netbuild/NBEdgeCont.cpp
@@ -1052,8 +1052,8 @@ NBEdgeCont::getByID(const std::string& edgeID) const {
 void
 NBEdgeCont::addPostProcessConnection(const std::string& from, int fromLane, const std::string& to, int toLane, bool mayDefinitelyPass,
                                      bool keepClear, double contPos, double visibility, double speed,
-                                     const PositionVector& customShape, bool uncontrolled, bool warnOnly) {
-    myConnections[from].push_back(PostProcessConnection(from, fromLane, to, toLane, mayDefinitelyPass, keepClear, contPos, visibility, speed, customShape, uncontrolled, warnOnly));
+                                     const PositionVector& customShape, bool uncontrolled, bool warnOnly, SVCPermissions permissions) {
+    myConnections[from].push_back(PostProcessConnection(from, fromLane, to, toLane, mayDefinitelyPass, keepClear, contPos, visibility, speed, customShape, uncontrolled, warnOnly, permissions));
 }
 
 bool

--- a/src/netbuild/NBEdgeCont.h
+++ b/src/netbuild/NBEdgeCont.h
@@ -540,7 +540,8 @@ public:
                                   bool keepClear, double contPos, double visibility, double speed,
                                   const PositionVector& customShape,
                                   bool uncontrolled,
-                                  bool warnOnly);
+                                  bool warnOnly,
+                                  SVCPermissions permissions = SVC_UNSPECIFIED);
 
     bool hasPostProcessConnection(const std::string& from, const std::string& to = "");
 
@@ -626,13 +627,14 @@ private:
                               bool mayDefinitelyPass_, bool keepClear_, double contPos_, double visibility_, double speed_,
                               const PositionVector& customShape_,
                               bool uncontrolled_,
-                              bool warnOnly_) :
+                              bool warnOnly_, SVCPermissions permissions_) :
             from(from_), fromLane(fromLane_), to(to_), toLane(toLane_), mayDefinitelyPass(mayDefinitelyPass_), keepClear(keepClear_), contPos(contPos_),
             visibility(visibility_),
             speed(speed_),
             customShape(customShape_),
             uncontrolled(uncontrolled_),
-            warnOnly(warnOnly_) {
+            warnOnly(warnOnly_),
+            permissions(permissions_) {
         }
         /// @brief The id of the edge the connection starts at
         std::string from;
@@ -652,6 +654,8 @@ private:
         double visibility;
         /// @brief custom speed for connection
         double speed;
+        /// @brief custom permissions for connection
+        SVCPermissions permissions;
         /// @brief custom shape for connection
         PositionVector customShape;
         /// @brief whether this connection shall not be controlled by a traffic light

--- a/src/netedit/GNEAttributeCarrier.cpp
+++ b/src/netedit/GNEAttributeCarrier.cpp
@@ -1824,6 +1824,19 @@ GNEAttributeCarrier::fillNetElements() {
                                            "-1");
         myTagProperties[currentTag].addAttribute(attrProperty);
 
+        attrProperty = AttributeProperties(SUMO_ATTR_ALLOW,
+                                           ATTRPROPERTY_VCLASS | ATTRPROPERTY_LIST | ATTRPROPERTY_DISCRETE | ATTRPROPERTY_DEFAULTVALUESTATIC | ATTRPROPERTY_VCLASSES,
+                                           "Explicitly allows the given vehicle classes (not given will be not allowed)",
+                                           "all");
+        attrProperty.setDiscreteValues(SumoVehicleClassStrings.getStrings());
+        myTagProperties[currentTag].addAttribute(attrProperty);
+
+        attrProperty = AttributeProperties(SUMO_ATTR_DISALLOW,
+                                           ATTRPROPERTY_VCLASS | ATTRPROPERTY_LIST | ATTRPROPERTY_DISCRETE | ATTRPROPERTY_DEFAULTVALUESTATIC | ATTRPROPERTY_VCLASSES,
+                                           "Explicitly disallows the given vehicle classes (not given will be allowed)");
+        attrProperty.setDiscreteValues(SumoVehicleClassStrings.getStrings());
+        myTagProperties[currentTag].addAttribute(attrProperty);
+
         attrProperty = AttributeProperties(SUMO_ATTR_SPEED,
                                            ATTRPROPERTY_FLOAT | ATTRPROPERTY_POSITIVE | ATTRPROPERTY_DEFAULTVALUESTATIC,
                                            "sets custom speed limit for the connection",

--- a/src/netimport/NIImporter_SUMO.cpp
+++ b/src/netimport/NIImporter_SUMO.cpp
@@ -201,7 +201,7 @@ NIImporter_SUMO::_loadNetwork(OptionsCont& oc) {
                 }
                 nbe->addLane2LaneConnection(
                     fromLaneIndex, toEdge, c.toLaneIdx, NBEdge::L2L_VALIDATED,
-                    true, c.mayDefinitelyPass, c.keepClear, c.contPos, c.visibility, c.speed, c.customShape, uncontrolled);
+                    true, c.mayDefinitelyPass, c.keepClear, c.contPos, c.visibility, c.speed, c.customShape, uncontrolled, c.permissions);
                 if (c.getParametersMap().size() > 0) {
                     nbe->getConnectionRef(fromLaneIndex, toEdge, c.toLaneIdx).updateParameters(c.getParametersMap());
                 }
@@ -755,6 +755,14 @@ NIImporter_SUMO::addConnection(const SUMOSAXAttributes& attrs) {
     conn.keepClear = attrs.getOpt<bool>(SUMO_ATTR_KEEP_CLEAR, nullptr, ok, true);
     conn.contPos = attrs.getOpt<double>(SUMO_ATTR_CONTPOS, nullptr, ok, NBEdge::UNSPECIFIED_CONTPOS);
     conn.visibility = attrs.getOpt<double>(SUMO_ATTR_VISIBILITY_DISTANCE, nullptr, ok, NBEdge::UNSPECIFIED_VISIBILITY_DISTANCE);
+    std::string allow = attrs.getOpt<std::string>(SUMO_ATTR_ALLOW, nullptr, ok, "", false);
+    std::string disallow = attrs.getOpt<std::string>(SUMO_ATTR_DISALLOW, nullptr, ok, "", false);
+    if (allow == "" && disallow == "") {
+        conn.permissions = SVC_UNSPECIFIED;
+    }
+    else {
+        conn.permissions = parseVehicleClasses(allow, disallow, myNetworkVersion);
+    }
     conn.speed = attrs.getOpt<double>(SUMO_ATTR_SPEED, nullptr, ok, NBEdge::UNSPECIFIED_SPEED);
     conn.customShape = attrs.getOpt<PositionVector>(SUMO_ATTR_SHAPE, nullptr, ok, PositionVector::EMPTY);
     NBNetBuilder::transformCoordinates(conn.customShape, false, myLocation);

--- a/src/netimport/NIImporter_SUMO.h
+++ b/src/netimport/NIImporter_SUMO.h
@@ -191,6 +191,8 @@ private:
         double contPos;
         /// @brief custom foe visibility for connection
         double visibility;
+        /// @brief custom permissions for connection
+        SVCPermissions permissions;
         /// @brief custom speed for connection
         double speed;
         /// @brief custom shape connection

--- a/src/netwrite/NWWriter_SUMO.cpp
+++ b/src/netwrite/NWWriter_SUMO.cpp
@@ -335,9 +335,10 @@ NWWriter_SUMO::writeInternalEdges(OutputDevice& into, const NBEdgeCont& ec, cons
                 // to avoid changing to an internal lane which has a successor
                 // with the wrong permissions we need to inherit them from the successor
                 const NBEdge::Lane& successor = (*k).toEdge->getLanes()[(*k).toLane];
+                SVCPermissions permissions = ((*k).permissions != SVC_UNSPECIFIED) ? (*k).permissions : successor.permissions;
                 const double width = n.isConstantWidthTransition() && (*i)->getNumLanes() > (*k).toEdge->getNumLanes() ? (*i)->getLaneWidth((*k).fromLane) : successor.width;
                 writeLane(into, (*k).getInternalLaneID(), (*k).vmax,
-                          successor.permissions, successor.preferred,
+                          permissions, successor.preferred,
                           NBEdge::UNSPECIFIED_OFFSET, NBEdge::UNSPECIFIED_OFFSET,
                           std::map<int, double>(), width, (*k).shape, &(*k),
                           (*k).length, (*k).internalLaneIndex, oppositeLaneID[(*k).getInternalLaneID()], "");
@@ -359,7 +360,8 @@ NWWriter_SUMO::writeInternalEdges(OutputDevice& into, const NBEdgeCont& ec, cons
                     into.openTag(SUMO_TAG_EDGE);
                     into.writeAttr(SUMO_ATTR_ID, (*k).viaID);
                     into.writeAttr(SUMO_ATTR_FUNCTION, EDGEFUNC_INTERNAL);
-                    writeLane(into, (*k).viaID + "_0", (*k).vmax, successor.permissions, successor.preferred,
+                    SVCPermissions permissions = ((*k).permissions != SVC_UNSPECIFIED)? (*k).permissions : successor.permissions;
+                    writeLane(into, (*k).viaID + "_0", (*k).vmax, permissions, successor.preferred,
                               NBEdge::UNSPECIFIED_OFFSET, NBEdge::UNSPECIFIED_OFFSET,
                               std::map<int, double>(), successor.width, (*k).viaShape, &(*k),
                               MAX2((*k).viaShape.length(), POSITION_EPS), // microsim needs positive length
@@ -682,6 +684,9 @@ NWWriter_SUMO::writeConnection(OutputDevice& into, const NBEdge& from, const NBE
     }
     if (c.visibility != NBEdge::UNSPECIFIED_VISIBILITY_DISTANCE && style != TLL) {
         into.writeAttr(SUMO_ATTR_VISIBILITY_DISTANCE, c.visibility);
+    }
+    if (c.permissions != SVC_UNSPECIFIED && style != TLL) {
+        writePermissions(into, c.permissions);
     }
     if (c.speed != NBEdge::UNSPECIFIED_SPEED && style != TLL) {
         into.writeAttr(SUMO_ATTR_SPEED, c.speed);


### PR DESCRIPTION
This pull request proposes a solution for #6217. Permissions are read/written for SUMO and plain XML formats. If the permissions have not been set explicitly in Netedit or specified in the plain XML or SUMO format, they should not be written to connection elements. The value SVC_UNSPECIFIED is used throughout the changes to reflect this situation and when building the network, the permissions of the successor lane are taken instead as it is now. 
The pull request completes the same netconvert tests successfully as the master branch currently does.

What the "PostProcessConnection" is used for? I have added the permissions there but am not sure they really are needed...