### PR TITLE
Ticket6420

### DIFF
--- a/src/microsim/devices/MSDevice_ElecHybrid.h
+++ b/src/microsim/devices/MSDevice_ElecHybrid.h
@@ -133,11 +133,11 @@ public:
     void setParameter(const std::string& key, const std::string& value);
 
     /** @brief Called on writing tripinfo output
-    *
-    * @param[in] os The stream to write the information into
-    * @exception IOError not yet implemented
-    * @see MSDevice::generateOutput
-    */
+     *
+     * @param[in] tripinfoOut The output device to write the information into
+     * @exception IOError not yet implemented
+     * @see MSDevice::tripInfoOutput
+     */
     void generateOutput(OutputDevice* tripinfoOut) const;
 
     /// @brief Get the actual vehicle's Battery Capacity in kWh
@@ -231,13 +231,35 @@ protected:
     /// @brief Parameter, Flag: Vehicle is charging (by default is false)
     bool myCharging;
 
-    /// @brief Parameter, Energy charged in each timestep
+    /// @brief Energy flowing into (+) or from (-) the battery pack in the given timestep
     double myEnergyCharged;
 
     /// @brief Parameter, Current wanted at overhead wire in next timestep
     double myCircuitCurrent;
 
     double myCircuitVoltage;
+
+    /// @name Tripinfo statistics
+    /// @{
+    double myMaxBatteryPower;
+    double myMinBatteryPower;
+    double myTotalPowerConsumed;
+    double myTotalPowerRegenerated;
+    
+    /// @brief Energy that could not be stored back to the battery or traction station
+    /// and was wasted on resistors. This is approximate, we ignore the use of classical
+    /// brakes in lower speeds.
+    double myTotalPowerWasted;
+    /// @}
+
+    /// @name Power management parameters
+    /// @{
+    /// @brief Minimal SOC of the battery pack, below this value the battery is assumed discharged
+    double mySOCMin;
+    /// @brief Maximal SOC of the battery pack, battery will not be charged above this level.
+    /// (But the buffer may still be used for regenerative braking).
+    double mySOCMax;
+    /// @}
 
     /// @brief Parameter, Pointer to the actual overhead wire segment in which vehicle is placed (by default is nullptr)
     MSOverheadWire* myActOverheadWireSegment;

--- a/src/microsim/trigger/MSOverheadWire.h
+++ b/src/microsim/trigger/MSOverheadWire.h
@@ -10,7 +10,7 @@
 /// @file    MSOverheadWire.h
 /// @author  Jakub Sevcik (RICE)
 /// @author  Jan Prikryl (RICE)
-/// @date    2019-11-25
+/// @date    2019-12-15
 ///
 // Overhead wires for Electric (equipped with elecHybrid device) vehicles (Overhead wire segments, overhead wire sections, traction substations)
 /****************************************************************************/
@@ -141,9 +141,8 @@ public:
         return myVoltageSource;
     }
 
-    MSTractionSubstation* getTractionSubstation() {
-        return myTractionSubstation;
-    }
+    void lock() const;
+    void unlock() const;
 
 protected:
 
@@ -309,6 +308,7 @@ private:
 public:   
     //preparation of overhead wire clamp
     struct OverheadWireClamp{
+        // @todo: 'MSTractionSubstation::overheadWireClamp' : no appropriate default constructor available 
         // provide default constructor for vector construction below
         OverheadWireClamp() :
             id("undefined"),

--- a/src/microsim/trigger/MSOverheadWire.h
+++ b/src/microsim/trigger/MSOverheadWire.h
@@ -36,6 +36,12 @@
 // Resistivity of Cu is 1.69*10^-8 Ohm*m. A cross-section S of the overhead wire used in Pilsen is 150 mm^2. So the "resistivity/S" is 0.000113 Ohm/m. 
 const double WIRE_RESISTIVITY = (double)2 * 0.000113;
 
+// Conversion macros
+#define WATTHR2JOULE(_x) ((_x)*3600.0)
+#define JOULE2WATTHR(_x) ((_x)/3600.0)
+#define WATTHR2WATT(_x) ((_x)*3600.0/TS)
+#define WATT2WATTHR(_x) ((_x)*TS/3600.0)
+
 // ===========================================================================
 // class declarations
 // ===========================================================================

--- a/src/utils/traction_wire/Circuit.cpp
+++ b/src/utils/traction_wire/Circuit.cpp
@@ -41,7 +41,7 @@ std::mutex circuit_lock;
 Node* Circuit::addNode(string name) {
     if (getNode(name) != nullptr) {
         //WRITE_ERROR("The node: '" + name + "' already exists.");
-        std::cout << "The node: '" + name + "' already exists.";
+        std::cout << "The node '" + name + "' already exists." << std::endl;
         return nullptr;
     }
 
@@ -156,8 +156,8 @@ void Circuit::unlock() {
 #ifdef HAVE_EIGEN
 void Circuit::removeColumn(Eigen::MatrixXd& matrix, unsigned int colToRemove)
 {
-    const int numRows = (int)matrix.rows();
-    const int numCols = (int)matrix.cols() - 1;
+    const unsigned int numRows = (unsigned int)matrix.rows();
+    const unsigned int numCols = (unsigned int)matrix.cols() - 1;
 
     if (colToRemove < numCols)
         matrix.block(0, colToRemove, numRows, numCols - colToRemove) = matrix.rightCols(numCols - colToRemove);

--- a/src/utils/traction_wire/Circuit.h
+++ b/src/utils/traction_wire/Circuit.h
@@ -10,10 +10,10 @@
 /// @file    Circuit.h
 /// @author  Jakub Sevcik (RICE)
 /// @author  Jan Prikryl (RICE)
-/// @date    2019-11-25
+/// @date    2019-12-15
+/// @note    based on work 2017 Ahmad Khaled, Ahmad Essam, Omnia Zakaria, Mary Nader
 ///
 // Representation of electric circuit of overhead wires
-// based on work 2017 Ahmad Khaled, Ahmad Essam, Omnia Zakaria, Mary Nader
 /****************************************************************************/
 #ifndef CIRCUIT_H
 #define CIRCUIT_H
@@ -49,6 +49,9 @@ public:
     Node* getNode(int id);
     Element* getVoltageSource(int id);
     vector<Element*> *getCurrentSources();
+
+    void lock();
+    void unlock();
     
     /**
      * @brief Best alpha scaling value.
@@ -109,7 +112,7 @@ private:
     /*
      *    removes the "colToRemove"-th column from matrix "matrix" 
      */
-    void removeColumn(Eigen::MatrixXd& matrix, const int colToRemove);
+    void removeColumn(Eigen::MatrixXd& matrix, const unsigned int colToRemove);
 
     /*
      * solves the system of nonlinear equations Ax = B(1/x)

--- a/src/utils/traction_wire/Element.cpp
+++ b/src/utils/traction_wire/Element.cpp
@@ -10,10 +10,10 @@
 /// @file    Element.cpp
 /// @author  Jakub Sevcik (RICE)
 /// @author  Jan Prikryl (RICE)
-/// @date    2019-11-25
+/// @date    2019-12-15
+/// @note    based on work 2017 Ahmad Khaled, Ahmad Essam, Omnia Zakaria, Mary Nader
 ///
 // Representation of electric circuit elements: resistors, voltage and current sources
-// based on work 2017 Ahmad Khaled, Ahmad Essam, Omnia Zakaria, Mary Nader
 /****************************************************************************/
 
 // ===========================================================================

--- a/src/utils/traction_wire/Element.h
+++ b/src/utils/traction_wire/Element.h
@@ -10,10 +10,10 @@
 /// @file    Element.h
 /// @author  Jakub Sevcik (RICE)
 /// @author  Jan Prikryl (RICE)
-/// @date    2019-11-25
+/// @date    2019-12-15
+/// @note    based on work 2017 Ahmad Khaled, Ahmad Essam, Omnia Zakaria, Mary Nader
 ///
 // Representation of electric circuit elements: resistors, voltage and current sources
-// based on work 2017 Ahmad Khaled, Ahmad Essam, Omnia Zakaria, Mary Nader
 /****************************************************************************/
 #ifndef ELEMENT_H
 #define ELEMENT_H

--- a/src/utils/traction_wire/Node.cpp
+++ b/src/utils/traction_wire/Node.cpp
@@ -10,10 +10,10 @@
 /// @file    Node.cpp
 /// @author  Jakub Sevcik (RICE)
 /// @author  Jan Prikryl (RICE)
-/// @date    2019-11-25
+/// @date    2019-12-15
+/// @note    based on work 2017 Ahmad Khaled, Ahmad Essam, Omnia Zakaria, Mary Nader
 ///
 // Representation of electric circuit nodes, i.e. wire junctions and connection points.
-// based on work 2017 Ahmad Khaled, Ahmad Essam, Omnia Zakaria, Mary Nader
 /****************************************************************************/
 
 // ===========================================================================
@@ -60,7 +60,7 @@ int Node::getNumOfElements() {
     return (int) elements->size();
 }
 
-string Node::getName() {
+string& Node::getName() {
     return this->name;
 }
 

--- a/src/utils/traction_wire/Node.h
+++ b/src/utils/traction_wire/Node.h
@@ -10,10 +10,10 @@
 /// @file    Node.h
 /// @author  Jakub Sevcik (RICE)
 /// @author  Jan Prikryl (RICE)
-/// @date    2019-11-25
+/// @date    2019-12-15
+/// @note    based on work 2017 Ahmad Khaled, Ahmad Essam, Omnia Zakaria, Mary Nader
 ///
 // Representation of electric circuit nodes, i.e. wire junctions and connection points.
-// based on work 2017 Ahmad Khaled, Ahmad Essam, Omnia Zakaria, Mary Nader
 /****************************************************************************/
 #ifndef NODE_H
 #define NODE_H
@@ -52,7 +52,7 @@ public:
     int getNumOfElements();
     // iterates through the vector of the node's elements and returns the first, which is not equal to "element" in the argument of the function
     Element* getAnOtherElement(Element* element);
-    string getName();
+    string& getName();
     bool isGround();
     bool isRemovable() { return isremovable; };
     void setGround(bool isground);


### PR DESCRIPTION
This PR shall resolve #6420.

It also 
* removes race conditions in GUI drawing subroutines that have to have access to the electric circuit data (I am open to suggestions how to get rid of the locking e.g. by copying the vital data to the GUI thread, but I am not sure about performance impact),
* adds conversion macros for converting between watt, watthour, and joule,
* corrects computation of circuit power parameters (accidentaly it was energy before) ,
* gets rid of redundant consumption computation in `MSDevice_ElecHybrid::notifyMove()` so probably the expected test results for `device/elechybrid` are going to change as well.

Jan