### PR TITLE
Align sumolib linkIndex calculation to MSRightOfWayJunction

### DIFF
--- a/tools/sumolib/net/node.py
+++ b/tools/sumolib/net/node.py
@@ -103,9 +103,13 @@ class Node:
                 index = lane_id[lastUnderscore+1:]
                 edge = [e for e in self._incoming if e.getID() == edge_id][0]
                 for candidate_conn in edge.getLane(int(index)).getOutgoing():
+                    fromFunction = candidate_conn.getFromLane().getEdge().getFunction()
+                    toFunction = candidate_conn.getToLane().getEdge().getFunction()
+                    if toFunction == "walkingarea" or (fromFunction == "walkingarea" and not toFunction == "crossing"):
+                        continue
                     if candidate_conn == conn:
                         return ret
-                    ret += 1
+                    ret += 1                    
         return -1
 
     def forbids(self, possProhibitor, possProhibited):


### PR DESCRIPTION
In SUMO itself, some connections at pedestrian crossings do not get assigned a proper linkIndex (see https://github.com/eclipse/sumo/blob/0ca713f74e5210fdf27dbd7c616d0830a7818c44/src/microsim/MSRightOfWayJunction.cpp#L87). This patch adds the missing conditions to sumolib, so that it returns the same linkIndex as SUMO.