### PR TITLE
Cosmetic changes to rotate parking vehicle into lot

### DIFF
--- a/src/microsim/MSParkingArea.h
+++ b/src/microsim/MSParkingArea.h
@@ -198,6 +198,25 @@ public:
      */
     int getLastFreeLotAngle() const;
 
+    /** @brief Return the GUI angle of myLastFreeLot - the angle the GUI uses to rotate into the next parking lot
+     *         as above, only expected to be called after we have established there is space in the parking area
+     *
+     * @return The GUI angle, relative to the lane, in radians
+     */
+        double getLastFreeLotGUIAngle() const;
+
+    /** @brief Return the manoeuver angle of the lot where the vehicle is parked
+     *
+     * @return The manoeuver angle in degrees
+     */
+     int getManoeuverAngle(const SUMOVehicle& forVehicle) const;
+
+    /** @brief  Return the GUI angle of the lot where the vehicle is parked
+     *
+     * @return The GUI angle, relative to the lane, in radians
+     */
+     double getGUIAngle(const SUMOVehicle& forVehicle) const;
+
     /** @brief Add a lot entry to parking area
      *
      * @param[in] x X position of the lot center
@@ -265,7 +284,9 @@ protected:
         /// @brief The position along the lane that the vehicle needs to reach for entering this lot
         double myEndPos;
         ///@brief The angle between lane and lot through which a vehicle must manoeuver to enter the lot
-        int myManoeuverAngle;
+        double myManoeuverAngle;
+        ///@brief Whether the lot is on the LHS of the lane relative to the lane direction
+        bool mySideIsLHS;
     };
 
 

--- a/src/microsim/MSVehicle.cpp
+++ b/src/microsim/MSVehicle.cpp
@@ -1446,6 +1446,11 @@ double
 MSVehicle::computeAngle() const {
     Position p1;
     const double posLat = -myState.myPosLat; // @todo get rid of the '-'
+
+    // if parking manoeuvre is happening then rotate vehicle on each step
+    if (MSGlobals::gModelParkingManoeuver && !manoeuvreIsComplete())
+        return getAngle() + myManoeuvre.getGUIIncrement();
+
     if (isParking()) {
         if (myStops.begin()->parkingarea != nullptr) {
             return myStops.begin()->parkingarea->getVehicleAngle(*this);
@@ -6493,14 +6498,14 @@ MSVehicle::setExitManoeuvre() {
  * methods of MSVehicle::manoeuvre
  * ----------------------------------------------------------------------- */
 
-MSVehicle::Manoeuvre::Manoeuvre() : myManoeuvreStop(""), myManoeuvreStartTime(0), myManoeuvreCompleteTime(0), myManoeuvreType(MSVehicle::MANOEUVRE_NONE), myManoeuvreAngle(0) {}
+MSVehicle::Manoeuvre::Manoeuvre() : myManoeuvreStop(""), myManoeuvreStartTime(0), myManoeuvreCompleteTime(0), myManoeuvreType(MSVehicle::MANOEUVRE_NONE), myGUIIncrement(0) {}
 
 MSVehicle::Manoeuvre::Manoeuvre(const Manoeuvre& manoeuvre) {
     myManoeuvreStop = manoeuvre.myManoeuvreStop;
     myManoeuvreStartTime = manoeuvre.myManoeuvreStartTime;
     myManoeuvreCompleteTime = manoeuvre.myManoeuvreCompleteTime;
     myManoeuvreType = manoeuvre.myManoeuvreType;
-    myManoeuvreAngle = manoeuvre.myManoeuvreAngle;
+    myGUIIncrement = manoeuvre.myGUIIncrement;
 }
 
 MSVehicle::Manoeuvre&
@@ -6509,7 +6514,7 @@ MSVehicle::Manoeuvre::operator=(const Manoeuvre& manoeuvre) {
     myManoeuvreStartTime = manoeuvre.myManoeuvreStartTime;
     myManoeuvreCompleteTime = manoeuvre.myManoeuvreCompleteTime;
     myManoeuvreType = manoeuvre.myManoeuvreType;
-    myManoeuvreAngle = manoeuvre.myManoeuvreAngle;
+    myGUIIncrement = manoeuvre.myGUIIncrement;
     return *this;
 }
 
@@ -6519,13 +6524,13 @@ MSVehicle::Manoeuvre::operator!=(const Manoeuvre& manoeuvre) {
             myManoeuvreStartTime != manoeuvre.myManoeuvreStartTime ||
             myManoeuvreCompleteTime != manoeuvre.myManoeuvreCompleteTime ||
             myManoeuvreType != manoeuvre.myManoeuvreType ||
-            myManoeuvreAngle != manoeuvre.myManoeuvreAngle
-           );
+            myGUIIncrement != manoeuvre.myGUIIncrement
+            );
 }
 
-int
-MSVehicle::Manoeuvre::getManoeuvreAngle() const {
-    return (myManoeuvreAngle);
+double
+MSVehicle::Manoeuvre::getGUIIncrement() const {
+    return (myGUIIncrement);
 }
 
 MSVehicle::ManoeuvreType
@@ -6559,16 +6564,20 @@ MSVehicle::Manoeuvre::configureEntryManoeuvre(MSVehicle* veh) {
     const SUMOTime currentTime = MSNet::getInstance()->getCurrentTimeStep();
     const Stop& stop = veh->getMyStops().front();
 
+    int manoeuverAngle = stop.parkingarea->getLastFreeLotAngle();
+    double GUIAngle = stop.parkingarea->getLastFreeLotGUIAngle();
+    if (abs(GUIAngle) < 0.1) GUIAngle = -0.1; // Wiggle vehicle on parallel entry
     myManoeuvreVehicleID = veh->getID();
     myManoeuvreStop = stop.parkingarea->getID();
     myManoeuvreType = MSVehicle::MANOEUVRE_ENTRY;
-    myManoeuvreAngle = stop.parkingarea->getLastFreeLotAngle();
     myManoeuvreStartTime = currentTime;
-    myManoeuvreCompleteTime = currentTime + veh->myType->getEntryManoeuvreTime(myManoeuvreAngle);
+    myManoeuvreCompleteTime = currentTime + veh->myType->getEntryManoeuvreTime(manoeuverAngle);
+    myGUIIncrement = GUIAngle / ((myManoeuvreCompleteTime - myManoeuvreStartTime) / (TS * 1000.));
+
 #ifdef DEBUG_STOPS
     if (veh->isSelected()) {
-        std::cout << "ENTRY manoeuvre start: vehicle=" << veh->getID() << " Angle=" << myManoeuvreAngle << " currentTime=" << currentTime <<
-                  " endTime=" << myManoeuvreCompleteTime << " manoeuvre time=" << myManoeuvreCompleteTime - currentTime << " parkArea=" << myManoeuvreStop << std::endl;
+       std::cout << "ENTRY manoeuvre start: vehicle=" << veh->getID() << " Manoeuvre Angle=" << manoeuverAngle << " Rotation angle=" << RAD2DEG(GUIAngle) << " Road Angle" << RAD2DEG(veh->getAngle()) << " increment=" << RAD2DEG(myGUIIncrement) << " currentTime=" << currentTime <<
+                    " endTime=" << myManoeuvreCompleteTime << " manoeuvre time=" << myManoeuvreCompleteTime - currentTime << " parkArea="<< myManoeuvreStop << std::endl;
     }
 #endif
 
@@ -6591,18 +6600,23 @@ MSVehicle::Manoeuvre::configureExitManoeuvre(MSVehicle* veh) {
 
     const SUMOTime currentTime = MSNet::getInstance()->getCurrentTimeStep();
 
+    int manoeuverAngle = veh->getCurrentParkingArea()->getManoeuverAngle(*veh);
+    double GUIAngle = veh->getCurrentParkingArea()->getGUIAngle(*veh);
+    if (abs(GUIAngle) < 0.1) GUIAngle = 0.1; // Wiggle vehicle on parallel exit
+
     myManoeuvreVehicleID = veh->getID();
     myManoeuvreStop = veh->getCurrentParkingArea()->getID();
     myManoeuvreType = MSVehicle::MANOEUVRE_EXIT;
     myManoeuvreStartTime = currentTime;
-    myManoeuvreCompleteTime = currentTime + veh->myType->getExitManoeuvreTime(myManoeuvreAngle);
+    myManoeuvreCompleteTime = currentTime + veh->myType->getExitManoeuvreTime(manoeuverAngle);
+    myGUIIncrement = (-GUIAngle) / ((myManoeuvreCompleteTime - myManoeuvreStartTime) / (TS * 1000.));
     if (veh->remainingStopDuration() > 0) {
         myManoeuvreCompleteTime += veh->remainingStopDuration();
     }
 
 #ifdef DEBUG_STOPS
     if (veh->isSelected()) {
-        std::cout << "EXIT manoeuvre start: vehicle=" << veh->getID() << " Angle=" << myManoeuvreAngle << " currentTime=" << currentTime
+        std::cout << "EXIT manoeuvre start: vehicle=" << veh->getID() << " Manoeuvre Angle=" << manoeuverAngle  << " increment=" << RAD2DEG(myGUIIncrement) << " currentTime=" << currentTime
                   << " endTime=" << myManoeuvreCompleteTime << " manoeuvre time=" << myManoeuvreCompleteTime - currentTime << " parkArea=" << myManoeuvreStop << std::endl;
     }
 #endif
@@ -6629,8 +6643,6 @@ MSVehicle::Manoeuvre::entryManoeuvreIsComplete(MSVehicle* veh) {
     } else if (MSNet::getInstance()->getCurrentTimeStep() < myManoeuvreCompleteTime) {
         return false;
     } else { // manoeuvre complete
-        // in case we ended up in a different lot - reset the angle for exit - to allow recompute
-        myManoeuvreAngle = currentStop->parkingarea->getLastFreeLotAngle();
         myManoeuvreType = MSVehicle::MANOEUVRE_NONE;
         return true;
     }

--- a/src/microsim/MSVehicle.h
+++ b/src/microsim/MSVehicle.h
@@ -1439,8 +1439,8 @@ public:
         bool
         manoeuvreIsComplete() const;
 
-        /// @brief Accessor for manoeuvre angle
-        int getManoeuvreAngle() const;
+        /// @brief Accessor for GUI rotation step when parking (radians)
+        double getGUIIncrement() const;
 
         /// @brief Accessor (get) for manoeuvre type
         MSVehicle::ManoeuvreType getManoeuvreType() const;
@@ -1464,8 +1464,8 @@ public:
         /// @brief Manoeuvre type - currently entry, exit or none
         ManoeuvreType myManoeuvreType;
 
-        // @brief Angle (degrees) through which manoeuver will turn vehicle - used to determine manouevre timing
-        int myManoeuvreAngle;
+        // @brief Angle (radians) through which parking vehicle moves in each sim step
+        double myGUIIncrement;
     };
 
     // Current or previous (completed) manoeuvre


### PR DESCRIPTION
Signed-off-by: theDiv <div@thoda.uk>
Purely cosmetic - obviously feel free to ignore!  (updated to remove irrelevant files)

If parking manoeuvering is enabled these changes rotate the vehicle into, or out of, the parking bay through the manoeuver sim steps.

These updates produce reasonably realistic manoeuvers with little impact on the simulation load.

Ideally the vehicle position at start of manoeuver would be adjusted depending on the bay angle but Ii couldn't do this reliably.