### PR TITLE
limit lanearea jam to detector length

### DIFF
--- a/src/microsim/output/MSE2Collector.cpp
+++ b/src/microsim/output/MSE2Collector.cpp
@@ -1197,7 +1197,7 @@ MSE2Collector::processJams(std::vector<JamInfo*>& jams, JamInfo* currentJam) {
         MoveNotificationInfo* lastVeh = *((*i)->lastStandingVehicle);
         MoveNotificationInfo* firstVeh = *((*i)->firstStandingVehicle);
         const double jamLengthInMeters = lastVeh->distToDetectorEnd
-                                         - firstVeh->distToDetectorEnd
+                                         - MAX2(0., firstVeh->distToDetectorEnd)
                                          + lastVeh->lengthOnDetector;
         const int jamLengthInVehicles = (int) distance((*i)->firstStandingVehicle, (*i)->lastStandingVehicle) + 1;
         // apply them to the statistics


### PR DESCRIPTION
As explained in #6642 , lanearea detectors should only return jam lengths which do not exceed the detected area. Before this PR, this has been respected only for the last but not for the first vehicle.
Signed-off-by: m-kro <m.barthauer@t-online.de>