### PR TITLE
Consider arrived vehicles for induction loop occupancy

### DIFF
--- a/src/microsim/output/MSInductLoop.cpp
+++ b/src/microsim/output/MSInductLoop.cpp
@@ -169,7 +169,7 @@ MSInductLoop::getOccupancy() const {
     const SUMOTime tbeg = SIMSTEP - DELTA_T;
     double occupancy = 0;
     const double csecond = SIMTIME;
-    for (const VehicleData& i : collectVehiclesOnDet(tbeg)) {
+    for (const VehicleData& i : collectVehiclesOnDet(tbeg, false, true)) {
         const double leaveTime = i.leaveTimeM == HAS_NOT_LEFT_DETECTOR ? csecond : MIN2(i.leaveTimeM, csecond);
         const double entryTime = MAX2(i.entryTimeM, STEPS2TIME(tbeg));
         occupancy += MIN2(leaveTime - entryTime, TS);
@@ -282,7 +282,7 @@ MSInductLoop::leaveDetectorByLaneChange(SUMOTrafficObject& veh, double /* lastPo
 
 
 std::vector<MSInductLoop::VehicleData>
-MSInductLoop::collectVehiclesOnDet(SUMOTime tMS, bool leaveTime) const {
+MSInductLoop::collectVehiclesOnDet(SUMOTime tMS, bool leaveTime, bool forOccupancy) const {
     const double t = STEPS2TIME(tMS);
     std::vector<VehicleData> ret;
     for (const VehicleData& i : myVehicleDataCont) {
@@ -296,7 +296,7 @@ MSInductLoop::collectVehiclesOnDet(SUMOTime tMS, bool leaveTime) const {
         }
     }
     for (const auto& i : myVehiclesOnDet) {
-        if (i.second >= t || leaveTime) { // no need to check leave time, they are still on the detector
+        if (i.second >= t || leaveTime || (i.second < t && forOccupancy)) { // no need to check leave time, they are still on the detector
             SUMOTrafficObject* const v = i.first;
             VehicleData d(v->getID(), v->getVehicleType().getLength(), i.second, HAS_NOT_LEFT_DETECTOR, v->getVehicleType().getID());
             d.speedM = v->getSpeed();

--- a/src/microsim/output/MSInductLoop.h
+++ b/src/microsim/output/MSInductLoop.h
@@ -285,9 +285,11 @@ public:
      * @param[in] t The time from which vehicles shall be counted
      * @param[in] leaveTime Whether entryTime or leaveTime shall be compared against t
      *            (the latter gives a more complete picture but may include vehicles in multiple steps even if they did not stay on the detector)
+     * @param[in] forOccupancy Whether the vehicle data shall be used for occupancy calculation and thus include vehicles which where already on the 
+                  detector before time t
      * @return The list of vehicles
      */
-    virtual std::vector<VehicleData> collectVehiclesOnDet(SUMOTime t, bool leaveTime = false) const;
+    virtual std::vector<VehicleData> collectVehiclesOnDet(SUMOTime t, bool leaveTime = false, bool forOccupancy = false) const;
 
     /// @brief allows for special color in the gui version
     virtual void setSpecialColor(const RGBColor* /*color*/) {};


### PR DESCRIPTION
Due to ongoing refactoring and semantic changes/corrections of the induction loop (see #3552), the detector occupancy does not consider vehicles which have already arrived on the detector more than one time step ago. This has a severe impact on any application relying on the occupancy data, e.g. external signal control, as at most times 0 will be returned.

@behrisch I understand that you are working on it. Nonetheless, occupancy output is a very basic and rather "old" feature and probably well used. Please think of accepting the pull request as long as there is no long-term solution.

Signed-off-by: m-kro <m.barthauer@t-online.de>