### PR TITLE
Add idling emissions for vehicles blocked on return from parking

### DIFF
--- a/src/mesosim/MEVehicle.cpp
+++ b/src/mesosim/MEVehicle.cpp
@@ -166,6 +166,10 @@ MEVehicle::isOnRoad() const {
     return getSegment() != nullptr;
 }
 
+bool
+MEVehicle::isIdling() const {
+    return false;
+}
 
 bool
 MEVehicle::isParking() const {

--- a/src/mesosim/MEVehicle.h
+++ b/src/mesosim/MEVehicle.h
@@ -144,6 +144,12 @@ public:
      */
     bool isOnRoad() const;
 
+    /** @brief Returns whether the vehicle is trying to re-enter the net
+     * @return true if the vehicle is trying to enter the net (eg after parking)
+     */
+    virtual bool isIdling() const;
+
+
     /** @brief Returns whether the vehicle is parking
      * @return whether the vehicle is parking
      */

--- a/src/microsim/MSMoveReminder.h
+++ b/src/microsim/MSMoveReminder.h
@@ -157,6 +157,19 @@ public:
         return true;
     }
 
+    /** @brief Computes idling emission values and adds them to the emission sums
+    *
+    * Idling implied by zero velocity, acceleration and slope
+    *
+    * @param[in] veh The vehicle
+    *
+    * @see MSMoveReminder::notifyMove
+    * @see PollutantsInterface
+    */
+    virtual bool notifyIdle(SUMOTrafficObject& veh ) {
+        UNUSED_PARAMETER(&veh);
+        return true;
+    }
 
     /** @brief Called if the vehicle leaves the reminder's lane
      *

--- a/src/microsim/MSVehicle.h
+++ b/src/microsim/MSVehicle.h
@@ -298,6 +298,12 @@ public:
     void workOnMoveReminders(double oldPos, double newPos, double newSpeed);
     //@}
 
+   /** @brief cycle through vehicle devices invoking notifyIdle
+     *
+     *   This is only implemented on the emissions device
+     *     implemented to allow capture of emissions when vehicle is not on net.
+     */
+    void workOnIdleReminders();
 
     /** @brief Returns whether the vehicle is supposed to take action in the current simulation step
      *         Updates myActionStep and myLastActionTime in case that the current simstep is an action step
@@ -573,6 +579,21 @@ public:
         return myAmOnNet;
     }
 
+    /** @brief access function for Idling flag
+     *      used to record whether vehicle is waiting to enter lane (after parking)
+     */
+    void
+    setIdling(bool amIdling) {
+        myAmIdling = amIdling;
+    }
+
+    /** @brief Returns whether a sim vehicle is waiting to enter a lane
+     *      (after parking has completed)
+     * @return true if the vehicle is waiting
+     */
+    inline bool isIdling() const {
+        return myAmIdling;
+    }
 
     /** @brief Returns whether the current simulation step is an action point for the vehicle
      * @return Whether the vehicle has an action point in the current step.
@@ -1926,6 +1947,9 @@ protected:
 
     /// @brief State of things of the vehicle that can be on or off
     int mySignals;
+
+    /// @brief Whether the vehicle is trying to enter the network (eg after parking so engine is running)
+    bool myAmIdling;
 
     /// @brief Whether the vehicle is on the network (not parking, teleported, vaporized, or arrived)
     bool myAmOnNet;

--- a/src/microsim/MSVehicleTransfer.cpp
+++ b/src/microsim/MSVehicleTransfer.cpp
@@ -119,6 +119,7 @@ MSVehicleTransfer::checkInsertions(SUMOTime time) {
             MSParkingArea* pa = desc.myVeh->getCurrentParkingArea();
             const double departPos = pa != nullptr ? pa->getInsertionPosition(*desc.myVeh) : desc.myVeh->getPositionOnLane();
             // handle parking vehicles
+            desc.myVeh->setIdling(true);
             if (desc.myVeh->getLane()->isInsertionSuccess(desc.myVeh, 0, departPos, desc.myVeh->getLateralPositionOnLane(),
                     false, MSMoveReminder::NOTIFICATION_PARKING)) {
                 MSNet::getInstance()->informVehicleStateListener(desc.myVeh, MSNet::VEHICLE_STATE_ENDING_PARKING);
@@ -127,9 +128,11 @@ MSVehicleTransfer::checkInsertions(SUMOTime time) {
                 if (MSGlobals::gModelParkingManoeuver && desc.myVeh->setExitManoeuvre()) {
                     MSNet::getInstance()->informVehicleStateListener(desc.myVeh, MSNet::VEHICLE_STATE_MANEUVERING);
                 }
+                desc.myVeh->setIdling(false);
                 i = vehInfos.erase(i);
             } else {
-                // blocked from entering the road
+                // blocked from entering the road - engine assumed to be idling.
+                desc.myVeh->workOnIdleReminders();
                 if (!desc.myVeh->signalSet(MSVehicle::VEH_SIGNAL_BLINKER_LEFT | MSVehicle::VEH_SIGNAL_BLINKER_RIGHT)) {
                     // signal wish to re-enter the road
                     desc.myVeh->switchOnSignal(MSGlobals::gLefthand ? MSVehicle::VEH_SIGNAL_BLINKER_RIGHT : MSVehicle::VEH_SIGNAL_BLINKER_LEFT);

--- a/src/microsim/devices/MSDevice_Emissions.cpp
+++ b/src/microsim/devices/MSDevice_Emissions.cpp
@@ -74,6 +74,13 @@ MSDevice_Emissions::notifyMove(SUMOTrafficObject& veh, double /*oldPos*/, double
     return true;
 }
 
+bool
+MSDevice_Emissions::notifyIdle(SUMOTrafficObject& veh) {
+    const SUMOEmissionClass c = veh.getVehicleType().getEmissionClass();
+    myEmissions.addScaled(PollutantsInterface::computeAll(c, 0., 0., 0.,
+                    static_cast<const SUMOVehicle&>(veh).getEmissionParameters()), TS);
+    return true;
+}
 
 void
 MSDevice_Emissions::notifyMoveInternal(const SUMOTrafficObject& veh,

--- a/src/microsim/devices/MSDevice_Emissions.h
+++ b/src/microsim/devices/MSDevice_Emissions.h
@@ -93,6 +93,18 @@ public:
         * @see PollutantsInterface
         */
     bool notifyMove(SUMOTrafficObject& veh, double oldPos, double newPos, double newSpeed);
+
+    /** @brief Computes idling emission values and adds them to the emission sums
+        *
+        * Idling implied by zero velocity, acceleration and slope
+        *
+        * @param[in] veh The vehicle
+        *
+        * @see MSMoveReminder::notifyMove
+        * @see PollutantsInterface
+        */
+    bool notifyIdle(SUMOTrafficObject& veh);
+
     /// @}
 
     /// @brief return the name for this type of device

--- a/src/microsim/devices/MSDevice_Tripinfo.cpp
+++ b/src/microsim/devices/MSDevice_Tripinfo.cpp
@@ -147,6 +147,19 @@ MSDevice_Tripinfo::cleanup() {
 }
 
 bool
+MSDevice_Tripinfo::notifyIdle(SUMOTrafficObject& veh) {
+    if (veh.isVehicle()) {
+        myWaitingTime += DELTA_T;
+        if (!myAmWaiting) {
+            myWaitingCount++;
+            myAmWaiting = true;
+        }
+    }
+    return true;
+}
+
+
+bool
 MSDevice_Tripinfo::notifyMove(SUMOTrafficObject& veh, double /*oldPos*/,
                               double /*newPos*/, double newSpeed) {
     if (veh.isStopped()) {

--- a/src/microsim/devices/MSDevice_Tripinfo.h
+++ b/src/microsim/devices/MSDevice_Tripinfo.h
@@ -112,6 +112,14 @@ public:
      */
     bool notifyMove(SUMOTrafficObject& veh, double oldPos, double newPos, double newSpeed);
 
+    /** @brief record idling as waiting time - cf issue 2233
+     *
+     * @param[in] veh The idling vehicle.
+     * @return Always true
+     *
+     * @see MSMoveReminder::notifyIdle
+     */
+    bool notifyIdle(SUMOTrafficObject& veh);
 
     /** @brief Saves departure info on insertion
      *

--- a/src/microsim/output/MSEmissionExport.cpp
+++ b/src/microsim/output/MSEmissionExport.cpp
@@ -43,7 +43,7 @@ MSEmissionExport::write(OutputDevice& of, SUMOTime timestep, int precision) {
     MSVehicleControl& vc = MSNet::getInstance()->getVehicleControl();
     for (MSVehicleControl::constVehIt it = vc.loadedVehBegin(); it != vc.loadedVehEnd(); ++it) {
         const SUMOVehicle* veh = it->second;
-        if (veh->isOnRoad()) {
+        if (veh->isOnRoad() || veh->isIdling()) {
             std::string fclass = veh->getVehicleType().getID();
             fclass = fclass.substr(0, fclass.find_first_of("@"));
             PollutantsInterface::Emissions emiss = PollutantsInterface::computeAll(

--- a/src/microsim/output/MSMeanData_Emissions.cpp
+++ b/src/microsim/output/MSMeanData_Emissions.cpp
@@ -79,6 +79,16 @@ MSMeanData_Emissions::MSLaneMeanDataValues::notifyMoveInternal(const SUMOTraffic
     }
 }
 
+bool
+MSMeanData_Emissions::MSLaneMeanDataValues::notifyIdle(SUMOTrafficObject& veh) {
+    if (veh.isVehicle()) {
+        myEmissions.addScaled(PollutantsInterface::computeAll(veh.getVehicleType().getEmissionClass(),
+            0., 0., 0.,
+        static_cast<const SUMOVehicle&>(veh).getEmissionParameters()), TS);
+    }
+    return true;
+}
+
 
 void
 MSMeanData_Emissions::MSLaneMeanDataValues::write(OutputDevice& dev, const SUMOTime period,

--- a/src/microsim/output/MSMeanData_Emissions.h
+++ b/src/microsim/output/MSMeanData_Emissions.h
@@ -100,6 +100,17 @@ public:
          */
         void notifyMoveInternal(const SUMOTrafficObject& veh, const double /* frontOnLane */, const double timeOnLane, const double /*meanSpeedFrontOnLane*/, const double meanSpeedVehicleOnLane, const double travelledDistanceFrontOnLane, const double travelledDistanceVehicleOnLane, const double /* meanLengthOnLane */);
 
+        /** @brief Computes idling emission values and adds them to the aggregate emission sums
+        *
+        * Idling implied by zero velocity, acceleration and slope
+        *
+        * @param[in] veh The vehicle
+        *
+        * @see MSMoveReminder::notifyMove
+        * @see PollutantsInterface
+        */
+        bool notifyIdle(SUMOTrafficObject& veh);
+
 
     private:
         /// @brief Collected values

--- a/src/utils/vehicle/SUMOVehicle.h
+++ b/src/utils/vehicle/SUMOVehicle.h
@@ -163,6 +163,11 @@ public:
      */
     virtual bool isOnRoad() const = 0;
 
+    /** @brief Returns whether the vehicle is idling (waiting to re-enter the net
+     * @return true if the vehicle is waiting to enter the net (eg after parking)
+    */
+    virtual bool isIdling() const = 0;
+
     /** @brief Returns the information whether the front of the vehhicle is on the given lane
      * @return Whether the vehicle's front is on that lane
      */

--- a/tests/sumo/output/emission-idling/detector.sumo
+++ b/tests/sumo/output/emission-idling/detector.sumo
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on Sat Feb 29 15:03:18 2020 by Eclipse SUMO Version v1_5_0-309-g1768c69365
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+SPDX-License-Identifier: EPL-2.0
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
+
+    <input>
+        <net-file value="net.net.xml"/>
+        <route-files value="input_routes.rou.xml"/>
+        <additional-files value="input_additional.add.xml"/>
+    </input>
+
+    <output>
+        <write-license value="true"/>
+        <emission-output value="rawdump.xml"/>
+        <tripinfo-output value="tripinfos.xml"/>
+    </output>
+
+    <time>
+        <begin value="0"/>
+        <end value="150"/>
+    </time>
+
+    <processing>
+        <default.speeddev value="0"/>
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+        <duration-log.disable value="true"/>
+        <no-step-log value="true"/>
+    </report>
+
+    <emissions>
+        <device.emissions.probability value="1"/>
+    </emissions>
+
+</configuration>
+-->
+
+<detector xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/det_e1_file.xsd">
+    <interval begin="0.00" end="150.00" id="ld1" nVehContrib="2" flow="48.00" occupancy="0.95" speed="7.01" harmonicMeanSpeed="7.01" length="5.00" nVehEntered="2"/>
+</detector>

--- a/tests/sumo/output/emission-idling/detector2.sumo
+++ b/tests/sumo/output/emission-idling/detector2.sumo
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on Sat Feb 29 15:03:18 2020 by Eclipse SUMO Version v1_5_0-309-g1768c69365
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+SPDX-License-Identifier: EPL-2.0
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
+
+    <input>
+        <net-file value="net.net.xml"/>
+        <route-files value="input_routes.rou.xml"/>
+        <additional-files value="input_additional.add.xml"/>
+    </input>
+
+    <output>
+        <write-license value="true"/>
+        <emission-output value="rawdump.xml"/>
+        <tripinfo-output value="tripinfos.xml"/>
+    </output>
+
+    <time>
+        <begin value="0"/>
+        <end value="150"/>
+    </time>
+
+    <processing>
+        <default.speeddev value="0"/>
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+        <duration-log.disable value="true"/>
+        <no-step-log value="true"/>
+    </report>
+
+    <emissions>
+        <device.emissions.probability value="1"/>
+    </emissions>
+
+</configuration>
+-->
+
+<meandata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/meandata_file.xsd">
+    <interval begin="0.00" end="150.00" id="ld1">
+        <edge id="E0" sampledSeconds="152.64" CO_abs="41.858920" CO2_abs="300851.039096" HC_abs="15.535421" PMx_abs="29.750969" NOx_abs="1192.288327" fuel_abs="113.884115" electricity_abs="0"
+            CO_normed="5.023070" CO2_normed="36102.124692" HC_normed="1.864250" PMx_normed="3.570116" NOx_normed="143.074599" fuel_normed="13.666094" electricity_normed="0"
+            traveltime="76.36" CO_perVeh="20.940400" CO2_perVeh="150504.145115" HC_perVeh="7.771770" PMx_perVeh="14.883260" NOx_perVeh="596.455761" fuel_perVeh="56.971821" electricity_perVeh="0"/>
+    </interval>
+</meandata>

--- a/tests/sumo/output/emission-idling/detector3.sumo
+++ b/tests/sumo/output/emission-idling/detector3.sumo
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on Sat Feb 29 15:03:18 2020 by Eclipse SUMO Version v1_5_0-309-g1768c69365
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+SPDX-License-Identifier: EPL-2.0
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
+
+    <input>
+        <net-file value="net.net.xml"/>
+        <route-files value="input_routes.rou.xml"/>
+        <additional-files value="input_additional.add.xml"/>
+    </input>
+
+    <output>
+        <write-license value="true"/>
+        <emission-output value="rawdump.xml"/>
+        <tripinfo-output value="tripinfos.xml"/>
+    </output>
+
+    <time>
+        <begin value="0"/>
+        <end value="150"/>
+    </time>
+
+    <processing>
+        <default.speeddev value="0"/>
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+        <duration-log.disable value="true"/>
+        <no-step-log value="true"/>
+    </report>
+
+    <emissions>
+        <device.emissions.probability value="1"/>
+    </emissions>
+
+</configuration>
+-->
+
+<meandata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/meandata_file.xsd">
+    <interval begin="0.00" end="150.00" id="ld1">
+        <edge id="E0">
+            <lane id="E0_0" sampledSeconds="152.64" CO_abs="41.858920" CO2_abs="300851.039096" HC_abs="15.535421" PMx_abs="29.750969" NOx_abs="1192.288327" fuel_abs="113.884115" electricity_abs="0"
+            CO_normed="5.023070" CO2_normed="36102.124692" HC_normed="1.864250" PMx_normed="3.570116" NOx_normed="143.074599" fuel_normed="13.666094" electricity_normed="0"
+            traveltime="76.36" CO_perVeh="20.940400" CO2_perVeh="150504.145115" HC_perVeh="7.771770" PMx_perVeh="14.883260" NOx_perVeh="596.455761" fuel_perVeh="56.971821" electricity_perVeh="0"/>
+        </edge>
+    </interval>
+</meandata>

--- a/tests/sumo/output/emission-idling/input_additional.add.xml
+++ b/tests/sumo/output/emission-idling/input_additional.add.xml
@@ -1,0 +1,6 @@
+<additional xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/additional_file.xsd">
+    <parkingArea id="pE0" lane="E0_0" startPos="120.00" endPos="130.00" roadsideCapacity="1" name="pE0" length="6"/>
+	<inductionLoop id="ld1" lane="E0_0" pos="140" freq="900" file="detector.xml" excludeEmpty="true"/>
+	<edgeData id="ld1" type="emissions"  file="detector2.xml" excludeEmpty="true"/>
+	<laneData id="ld1" type="emissions"  file="detector3.xml" excludeEmpty="true"/>
+</additional>

--- a/tests/sumo/output/emission-idling/input_routes.rou.xml
+++ b/tests/sumo/output/emission-idling/input_routes.rou.xml
@@ -1,0 +1,11 @@
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/routes_file.xsd">
+    <vType id="passenger" vClass="passenger" emissionClass="PHEMlight/PC_D_EU4" personCapacity="1"/>
+    <route edges="E0" color="yellow" id="r0"/>
+    <vehicle id="ve0" depart="0.00" route="r0" type="passenger">
+        <stop parkingArea="pE0" duration="30.00"/>
+    </vehicle>
+    <vehicle id="ve1" depart="0.00" color="red" route="r0" type="passenger">
+        <stop lane="E0_0" startPos="128.00" endPos="130.00" duration="100.00"/>
+    </vehicle>
+</routes>
+

--- a/tests/sumo/output/emission-idling/net.net.xml
+++ b/tests/sumo/output/emission-idling/net.net.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<net version="1.6" junctionCornerDetail="5" lefthand="true" limitTurnSpeed="5.50" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/net_file.xsd">
+    <location netOffset="0.00,-0.00" convBoundary="0.00,0.00,200.00,0.00" origBoundary="10000000000.00,10000000000.00,-10000000000.00,-10000000000.00" projParameter="!"/>
+
+    <edge id="E0" from="J0" to="J1" priority="-1" length="200.00">
+        <lane id="E0_0" index="0" speed="13.89" length="200.00" shape="0.00,1.60 200.00,1.60"/>
+    </edge>
+
+    <junction id="J0" type="dead_end" x="0.00" y="0.00" incLanes="" intLanes="" shape="0.00,-0.00 0.00,3.20"/>
+    <junction id="J1" type="dead_end" x="200.00" y="0.00" incLanes="E0_0" intLanes="" shape="200.00,3.20 200.00,-0.00"/>
+</net>

--- a/tests/sumo/output/emission-idling/options.sumo
+++ b/tests/sumo/output/emission-idling/options.sumo
@@ -1,0 +1,1 @@
+--no-step-log --no-duration-log --net-file=net.net.xml --routes=input_routes.rou.xml -a input_additional.add.xml --tripinfo-output=tripinfos.xml --device.emissions.probability=1.0 --emission-output=rawdump.xml -b 0 -e 150 

--- a/tests/sumo/output/emission-idling/rawdump.sumo
+++ b/tests/sumo/output/emission-idling/rawdump.sumo
@@ -1,0 +1,558 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on Sat Feb 29 14:39:05 2020 by Eclipse SUMO Version v1_5_0-309-g1768c69365
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+SPDX-License-Identifier: EPL-2.0
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
+
+    <input>
+        <net-file value="net.net.xml"/>
+        <route-files value="input_routes.rou.xml"/>
+        <additional-files value="input_additional.add.xml"/>
+    </input>
+
+    <output>
+        <write-license value="true"/>
+        <emission-output value="rawdump.xml"/>
+        <tripinfo-output value="tripinfos.xml"/>
+    </output>
+
+    <time>
+        <begin value="0"/>
+        <end value="150"/>
+    </time>
+
+    <processing>
+        <default.speeddev value="0"/>
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+        <duration-log.disable value="true"/>
+        <no-step-log value="true"/>
+    </report>
+
+    <emissions>
+        <device.emissions.probability value="1"/>
+    </emissions>
+
+</configuration>
+-->
+
+<emission-export xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/emission_file.xsd">
+    <timestep time="0.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="5.10" speed="0.00" angle="90.00" x="5.10" y="1.60"/>
+    </timestep>
+    <timestep time="1.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="2331.57" CO="0.40" HC="0.16" NOx="5.63" PMx="0.25" fuel="0.88" electricity="0.00" noise="62.83" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="6.54" speed="1.44" angle="90.00" x="6.54" y="1.60"/>
+    </timestep>
+    <timestep time="2.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="3777.88" CO="0.67" HC="0.21" NOx="11.13" PMx="0.43" fuel="1.43" electricity="0.00" noise="64.53" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="9.66" speed="3.12" angle="90.00" x="9.66" y="1.60"/>
+    </timestep>
+    <timestep time="3.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="7494.78" CO="0.88" HC="0.27" NOx="33.07" PMx="0.79" fuel="2.84" electricity="0.00" noise="69.40" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="15.31" speed="5.66" angle="90.00" x="15.31" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="5.10" speed="0.00" angle="90.00" x="5.10" y="1.60"/>
+    </timestep>
+    <timestep time="4.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="7017.32" CO="0.89" HC="0.26" NOx="30.35" PMx="0.77" fuel="2.66" electricity="0.00" noise="67.79" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="22.93" speed="7.62" angle="90.00" x="22.93" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="2854.82" CO="0.51" HC="0.18" NOx="7.75" PMx="0.31" fuel="1.08" electricity="0.00" noise="64.71" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="6.93" speed="1.83" angle="90.00" x="6.93" y="1.60"/>
+    </timestep>
+    <timestep time="5.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="9581.87" CO="1.42" HC="0.26" NOx="59.74" PMx="0.86" fuel="3.63" electricity="0.00" noise="71.46" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="33.09" speed="10.16" angle="90.00" x="33.09" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="3955.33" CO="0.71" HC="0.21" NOx="11.80" PMx="0.45" fuel="1.50" electricity="0.00" noise="64.51" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="10.40" speed="3.47" angle="90.00" x="10.40" y="1.60"/>
+    </timestep>
+    <timestep time="6.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="10028.06" CO="1.60" HC="0.28" NOx="61.13" PMx="0.89" fuel="3.80" electricity="0.00" noise="71.46" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="45.53" speed="12.44" angle="90.00" x="45.53" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="5685.14" CO="0.86" HC="0.23" NOx="21.13" PMx="0.65" fuel="2.15" electricity="0.00" noise="66.45" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="15.76" speed="5.36" angle="90.00" x="15.76" y="1.60"/>
+    </timestep>
+    <timestep time="7.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="3692.08" CO="0.66" HC="0.20" NOx="10.80" PMx="0.42" fuel="1.40" electricity="0.00" noise="65.19" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="58.45" speed="12.92" angle="90.00" x="58.45" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="8555.34" CO="0.93" HC="0.27" NOx="42.64" PMx="0.75" fuel="3.24" electricity="0.00" noise="70.65" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="23.71" speed="7.95" angle="90.00" x="23.71" y="1.60"/>
+    </timestep>
+    <timestep time="8.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="2225.75" CO="0.37" HC="0.16" NOx="5.24" PMx="0.23" fuel="0.84" electricity="0.00" noise="64.18" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="71.47" speed="13.02" angle="90.00" x="71.47" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="8176.15" CO="0.89" HC="0.27" NOx="38.75" PMx="0.78" fuel="3.09" electricity="0.00" noise="69.06" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="33.65" speed="9.94" angle="90.00" x="33.65" y="1.60"/>
+    </timestep>
+    <timestep time="9.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="2936.29" CO="0.52" HC="0.19" NOx="8.02" PMx="0.32" fuel="1.11" electricity="0.00" noise="64.89" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="84.77" speed="13.30" angle="90.00" x="84.77" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="8523.28" CO="0.93" HC="0.27" NOx="42.32" PMx="0.76" fuel="3.23" electricity="0.00" noise="69.46" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="45.46" speed="11.81" angle="90.00" x="45.46" y="1.60"/>
+    </timestep>
+    <timestep time="10.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="2785.95" CO="0.50" HC="0.18" NOx="7.53" PMx="0.31" fuel="1.05" electricity="0.00" noise="64.93" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="98.32" speed="13.55" angle="90.00" x="98.32" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="9821.47" CO="1.54" HC="0.27" NOx="60.67" PMx="0.88" fuel="3.72" electricity="0.00" noise="71.04" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="59.27" speed="13.81" angle="90.00" x="59.27" y="1.60"/>
+    </timestep>
+    <timestep time="11.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="0.00" CO="0.00" HC="0.00" NOx="0.00" PMx="0.00" fuel="0.00" electricity="0.00" noise="62.15" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="111.07" speed="12.75" angle="90.00" x="111.07" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="0.00" CO="0.00" HC="0.00" NOx="0.00" PMx="0.00" fuel="0.00" electricity="0.00" noise="63.53" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="72.74" speed="13.47" angle="90.00" x="72.74" y="1.60"/>
+    </timestep>
+    <timestep time="12.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="0.00" CO="0.00" HC="0.00" NOx="0.00" PMx="0.00" fuel="0.00" electricity="0.00" noise="57.34" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="120.99" speed="9.92" angle="90.00" x="120.99" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="3338.94" CO="0.59" HC="0.20" NOx="9.47" PMx="0.37" fuel="1.26" electricity="0.00" noise="65.43" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="86.57" speed="13.83" angle="90.00" x="86.57" y="1.60"/>
+    </timestep>
+    <timestep time="13.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="0.00" CO="0.00" HC="0.00" NOx="0.00" PMx="0.00" fuel="0.00" electricity="0.00" noise="51.11" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="127.08" speed="6.09" angle="90.00" x="127.08" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="0.00" CO="0.00" HC="0.00" NOx="0.00" PMx="0.00" fuel="0.00" electricity="0.00" noise="63.55" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="100.06" speed="13.49" angle="90.00" x="100.06" y="1.60"/>
+    </timestep>
+    <timestep time="14.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="0.00" CO="0.00" HC="0.00" NOx="0.00" PMx="0.00" fuel="0.00" electricity="0.00" noise="41.66" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.18" speed="2.10" angle="90.00" x="129.18" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="0.00" CO="0.00" HC="0.00" NOx="0.00" PMx="0.00" fuel="0.00" electricity="0.00" noise="57.68" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="110.38" speed="10.31" angle="90.00" x="110.38" y="1.60"/>
+    </timestep>
+    <timestep time="15.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="49.03" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.66" speed="0.48" angle="90.00" x="129.66" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="0.00" CO="0.00" HC="0.00" NOx="0.00" PMx="0.00" fuel="0.00" electricity="0.00" noise="52.41" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="117.12" speed="6.75" angle="90.00" x="117.12" y="1.60"/>
+    </timestep>
+    <timestep time="16.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.11" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.93" speed="0.27" angle="90.00" x="129.93" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="0.00" CO="0.00" HC="0.00" NOx="0.00" PMx="0.00" fuel="0.00" electricity="0.00" noise="48.70" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="121.18" speed="4.06" angle="90.00" x="121.18" y="1.60"/>
+    </timestep>
+    <timestep time="17.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="0.00" CO="0.00" HC="0.00" NOx="0.00" PMx="0.00" fuel="0.00" electricity="0.00" noise="44.22" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="122.41" speed="1.23" angle="90.00" x="122.41" y="1.60"/>
+    </timestep>
+    <timestep time="18.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="4892.67" CO="0.81" HC="0.22" NOx="17.42" PMx="0.59" fuel="1.85" electricity="0.00" noise="67.00" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="125.85" speed="3.44" angle="90.00" x="125.85" y="1.60"/>
+    </timestep>
+    <timestep time="19.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="1384.59" CO="0.22" HC="0.12" NOx="3.09" PMx="0.15" fuel="0.52" electricity="0.00" noise="56.15" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.01" speed="3.16" angle="90.00" x="129.01" y="1.60"/>
+    </timestep>
+    <timestep time="20.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="0.00" CO="0.00" HC="0.00" NOx="0.00" PMx="0.00" fuel="0.00" electricity="0.00" noise="46.48" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.92" speed="0.91" angle="90.00" x="129.92" y="1.60"/>
+    </timestep>
+    <timestep time="21.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="52.11" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.04" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="22.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.76" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="23.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="24.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="25.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="26.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="27.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="28.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="29.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="30.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="31.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="32.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="33.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="34.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="35.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="36.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="37.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="38.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="39.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="40.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="41.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="42.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="43.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="44.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="45.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="46.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="47.00">
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="48.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="1.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="49.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="2.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="50.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="3.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="51.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="4.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="52.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="5.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="53.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="6.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="54.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="7.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="55.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="8.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="56.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="9.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="57.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="10.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="58.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="11.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="59.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="12.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="60.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="13.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="61.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="14.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="62.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="15.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="63.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="16.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="64.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="17.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="65.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="18.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="66.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="19.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="67.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="20.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="68.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="21.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="69.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="22.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="70.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="23.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="71.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="24.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="72.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="25.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="73.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="26.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="74.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="27.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="75.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="28.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="76.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="29.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="77.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="30.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="78.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="31.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="79.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="32.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="80.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="33.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="81.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="34.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="82.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="35.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="83.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="36.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="84.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="37.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="85.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="38.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="86.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="39.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="87.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="40.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="88.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="41.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="89.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="42.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="90.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="43.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="91.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="44.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="92.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="45.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="93.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="46.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="94.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="47.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="95.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="48.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="96.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="49.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="97.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="50.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="98.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="51.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="99.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="52.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="100.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="53.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="101.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="54.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="102.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="55.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="103.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="56.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="104.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="57.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="105.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="58.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="106.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="59.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="107.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="60.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="108.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="61.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="109.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="62.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="110.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="63.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="111.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="64.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="112.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="65.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="113.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="66.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="114.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="67.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="115.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="68.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="116.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="69.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="117.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="70.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="118.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="71.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="119.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="72.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="120.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="73.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="121.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="74.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.94" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="129.96" speed="0.00" angle="90.00" x="129.96" y="1.60"/>
+    </timestep>
+    <timestep time="122.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="75.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="2848.32" CO="0.51" HC="0.18" NOx="7.73" PMx="0.31" fuel="1.08" electricity="0.00" noise="64.69" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="131.79" speed="1.83" angle="90.00" x="131.79" y="1.60"/>
+    </timestep>
+    <timestep time="123.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.03" route="r0" type="passenger" waiting="76.00" lane="E0_0" pos="130.00" speed="0.06" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="4485.86" CO="0.77" HC="0.22" NOx="14.88" PMx="0.53" fuel="1.70" electricity="0.00" noise="65.56" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="135.48" speed="3.68" angle="90.00" x="135.48" y="1.60"/>
+    </timestep>
+    <timestep time="124.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="508.15" CO="0.07" HC="0.04" NOx="1.65" PMx="0.04" fuel="0.19" electricity="0.00" noise="55.00" route="r0" type="passenger" waiting="76.00" lane="E0_0" pos="130.00" speed="0.00" angle="90.00" x="130.00" y="4.80"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="7651.54" CO="0.88" HC="0.27" NOx="33.96" PMx="0.79" fuel="2.90" electricity="0.00" noise="69.29" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="141.63" speed="6.15" angle="90.00" x="141.63" y="1.60"/>
+    </timestep>
+    <timestep time="125.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="2736.08" CO="0.49" HC="0.18" NOx="7.36" PMx="0.30" fuel="1.04" electricity="0.00" noise="64.39" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="131.77" speed="1.77" angle="90.00" x="131.77" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="5617.58" CO="0.86" HC="0.23" NOx="20.84" PMx="0.65" fuel="2.13" electricity="0.00" noise="65.81" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="149.26" speed="7.64" angle="90.00" x="149.26" y="1.60"/>
+    </timestep>
+    <timestep time="126.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="3332.85" CO="0.59" HC="0.20" NOx="9.44" PMx="0.37" fuel="1.26" electricity="0.00" noise="63.22" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="134.90" speed="3.14" angle="90.00" x="134.90" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="6434.65" CO="0.89" HC="0.24" NOx="25.70" PMx="0.71" fuel="2.44" electricity="0.00" noise="66.78" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="158.43" speed="9.17" angle="90.00" x="158.43" y="1.60"/>
+    </timestep>
+    <timestep time="127.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="7640.85" CO="0.88" HC="0.27" NOx="33.87" PMx="0.79" fuel="2.89" electricity="0.00" noise="69.60" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="140.62" speed="5.72" angle="90.00" x="140.62" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="8324.02" CO="0.90" HC="0.27" NOx="40.27" PMx="0.77" fuel="3.15" electricity="0.00" noise="69.17" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="169.49" speed="11.06" angle="90.00" x="169.49" y="1.60"/>
+    </timestep>
+    <timestep time="128.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="5355.31" CO="0.84" HC="0.23" NOx="19.72" PMx="0.63" fuel="2.03" electricity="0.00" noise="65.41" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="147.79" speed="7.17" angle="90.00" x="147.79" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="7057.26" CO="0.89" HC="0.26" NOx="30.67" PMx="0.77" fuel="2.67" electricity="0.00" noise="67.69" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="181.87" speed="12.38" angle="90.00" x="181.87" y="1.60"/>
+    </timestep>
+    <timestep time="129.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="5806.20" CO="0.87" HC="0.23" NOx="21.64" PMx="0.66" fuel="2.20" electricity="0.00" noise="66.05" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="156.38" speed="8.59" angle="90.00" x="156.38" y="1.60"/>
+        <vehicle id="ve1" eclass="PHEMlight/PC_D_EU4" CO2="5508.46" CO="0.85" HC="0.23" NOx="20.37" PMx="0.64" fuel="2.09" electricity="0.00" noise="66.65" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="195.13" speed="13.26" angle="90.00" x="195.13" y="1.60"/>
+    </timestep>
+    <timestep time="130.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="8869.25" CO="1.07" HC="0.26" NOx="49.13" PMx="0.78" fuel="3.36" electricity="0.00" noise="70.10" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="167.12" speed="10.74" angle="90.00" x="167.12" y="1.60"/>
+    </timestep>
+    <timestep time="131.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="7885.46" CO="0.87" HC="0.27" NOx="35.89" PMx="0.80" fuel="2.98" electricity="0.00" noise="68.54" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="179.43" speed="12.30" angle="90.00" x="179.43" y="1.60"/>
+    </timestep>
+    <timestep time="132.00">
+        <vehicle id="ve0" eclass="PHEMlight/PC_D_EU4" CO2="5917.23" CO="0.88" HC="0.23" NOx="22.12" PMx="0.66" fuel="2.24" electricity="0.00" noise="66.96" route="r0" type="passenger" waiting="0.00" lane="E0_0" pos="192.71" speed="13.28" angle="90.00" x="192.71" y="1.60"/>
+    </timestep>
+    <timestep time="133.00"/>
+    <timestep time="134.00"/>
+    <timestep time="135.00"/>
+    <timestep time="136.00"/>
+    <timestep time="137.00"/>
+    <timestep time="138.00"/>
+    <timestep time="139.00"/>
+    <timestep time="140.00"/>
+    <timestep time="141.00"/>
+    <timestep time="142.00"/>
+    <timestep time="143.00"/>
+    <timestep time="144.00"/>
+    <timestep time="145.00"/>
+    <timestep time="146.00"/>
+    <timestep time="147.00"/>
+    <timestep time="148.00"/>
+    <timestep time="149.00"/>
+</emission-export>

--- a/tests/sumo/output/emission-idling/tripinfos.sumo
+++ b/tests/sumo/output/emission-idling/tripinfos.sumo
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- generated on Sat Feb 29 10:12:01 2020 by Eclipse SUMO Version v1_5_0-309-g1768c69365
+This data file and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v20.html
+SPDX-License-Identifier: EPL-2.0
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/sumoConfiguration.xsd">
+
+    <input>
+        <net-file value="net.net.xml"/>
+        <route-files value="input_routes.rou.xml"/>
+        <additional-files value="input_additional2.add.xml"/>
+    </input>
+
+    <output>
+        <write-license value="true"/>
+        <emission-output value="rawdump.xml"/>
+        <tripinfo-output value="tripinfos.xml"/>
+    </output>
+
+    <time>
+        <begin value="0"/>
+        <end value="1000"/>
+    </time>
+
+    <processing>
+        <default.speeddev value="0"/>
+    </processing>
+
+    <report>
+        <xml-validation value="never"/>
+        <duration-log.disable value="true"/>
+        <no-step-log value="true"/>
+    </report>
+
+    <emissions>
+        <device.emissions.probability value="1"/>
+    </emissions>
+
+</configuration>
+-->
+
+<tripinfos xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/tripinfo_file.xsd">
+    <tripinfo id="ve1" depart="3.00" departLane="E0_0" departPos="5.10" departSpeed="0.00" departDelay="3.00" arrival="130.00" arrivalLane="E0_0" arrivalPos="200.00" arrivalSpeed="13.67" duration="127.00" routeLength="194.90" waitingTime="0.00" waitingCount="0" stopTime="101.00" timeLoss="11.34" rerouteNo="0" devices="tripinfo_ve1 emissions_ve1" vType="passenger" speedFactor="1.00" vaporized="">
+        <emissions CO_abs="21.936815" CO2_abs="159974.246178" HC_abs="8.306114" PMx_abs="15.816550" NOx_abs="626.749187" fuel_abs="60.556495" electricity_abs="0"/>
+    </tripinfo>
+    <tripinfo id="ve0" depart="0.00" departLane="E0_0" departPos="5.10" departSpeed="0.00" departDelay="0.00" arrival="133.00" arrivalLane="E0_0" arrivalPos="200.00" arrivalSpeed="13.45" duration="133.00" routeLength="194.90" waitingTime="76.00" waitingCount="1" stopTime="108.00" timeLoss="10.53" rerouteNo="0" devices="tripinfo_ve0 emissions_ve0" vType="passenger" speedFactor="1.00" vaporized="">
+        <emissions CO_abs="20.134716" CO2_abs="142076.944008" HC_abs="7.299877" PMx_abs="14.068540" NOx_abs="568.932999" fuel_abs="53.781963" electricity_abs="0"/>
+    </tripinfo>
+</tripinfos>

--- a/tests/sumo/output/testsuite.sumo
+++ b/tests/sumo/output/testsuite.sumo
@@ -80,3 +80,6 @@ duration_log
 # Tests which serve as examples
 examples
 examples_multimodal
+
+# test capture of idling emissions
+emission-idling


### PR DESCRIPTION
Signed-off-by: theDiv <div@thoda.uk>

Introduces an 'idling' state to allow capture of emissions from vehicles waiting to enter the net and add this blocked time as waiting time. (Issue 2233)

As-is emission models have these reconciliation discrepancies which have not been addressed in these changes:
a) Emission output does not reconcile with tripinfo because tripinfo 'loses' the first emission value for each vehicle and the emissions output 'loses' the last value for each vehicle.

b) tripinfo and edge/lane emissions sometimes fail to reconcile because edge/lane emissions apply a scaling value when the last timestep is shorter than TS.

Changes to GUIVehicle.cpp to follow - fixing coloring by emission of parking/idling vehicles. 

