### PR TITLE
Do not return the leader if it is further than the required distance

### DIFF
--- a/src/microsim/MSVehicle.cpp
+++ b/src/microsim/MSVehicle.cpp
@@ -5435,7 +5435,6 @@ MSVehicle::getDistanceToPosition(double destPos, const MSEdge* destEdge) const {
     return distance;
 }
 
-
 std::pair<const MSVehicle* const, double>
 MSVehicle::getLeader(double dist) const {
     if (myLane == nullptr) {
@@ -5453,8 +5452,12 @@ MSVehicle::getLeader(double dist) const {
         lead = *(it + 1);
     }
     if (lead != nullptr) {
-        std::pair<const MSVehicle* const, double> result(
-            lead, lead->getBackPositionOnLane(myLane) - getPositionOnLane() - getVehicleType().getMinGap());
+        double gap = lead->getBackPositionOnLane(myLane) - getPositionOnLane() - getVehicleType().getMinGap();
+        if (gap > dist) {
+            lead = nullptr;
+            gap = -1;
+        }
+        std::pair<const MSVehicle* const, double> result(lead, gap);
         lane->releaseVehicles();
         return result;
     }


### PR DESCRIPTION
When the distance from the ego vehicle to its leader is greater than the desired distance, the pair (0, -1) should be returned. Currently, the leader is returned regardless of its distance.


Signed-off-by: andreastedile <andrea.stedile@studenti.unitn.it>