### PR TITLE
createVehTypeDistribution to allow emissionsClass with numeric characters 

### DIFF
--- a/tools/createVehTypeDistribution.py
+++ b/tools/createVehTypeDistribution.py
@@ -228,7 +228,10 @@ def readConfigFile(options):
                             break
 
                     if not distFound:
-                        isNumeric = len(re.findall(r'(-?[0-9]+(\.[0-9]+)?)', attValue)) > 0
+                        if attName == "emissionClass":
+                            isNumeric = False
+                        else:
+                            isNumeric = len(re.findall(r'(-?[0-9]+(\.[0-9]+)?)', attValue)) > 0
                         value = FixDistribution((attValue,), isNumeric)
 
                     # get optional limits


### PR DESCRIPTION
When listing an emissions class such as 'HBEFA3/PC_G_EU4' in the parameter.txt file for createVehTypeDistribution.py, the numeric characters caused the argument to be marked as numeric.

Caused an error at Line 55: https://github.com/mschrader15/sumo/blob/b9b859b59956d4a408eac5ecb51144e371effe66/tools/createVehTypeDistribution.py#L55

Signed-off-by: Maxwell Schrader <mcschrader@crimson.ua.edu>