### PR TITLE
Better float check for createVehDistribution.py

### DIFF
--- a/tools/createVehTypeDistribution.py
+++ b/tools/createVehTypeDistribution.py
@@ -231,7 +231,7 @@ def readConfigFile(options):
                         if attName == "emissionClass":
                             isNumeric = False
                         else:
-                            isNumeric = len(re.findall(r'(-?[0-9]+(\.[0-9]+)?)', attValue)) > 0
+                            isNumeric = len(re.findall(r'^(-?[0-9]+(\.[0-9]+)?)$', attValue)) > 0
                         value = FixDistribution((attValue,), isNumeric)
 
                     # get optional limits


### PR DESCRIPTION
Currently, other values starting with numbers would be qualified as numeric, even if they aren't. As spaces are stripped before the type check, we can use the regex start/end notation to avoid misclassified data.
Signed-off-by: m-kro <m.barthauer@t-online.de>