### PR TITLE
Add tolerance to floating point imprecision in positionAtOffset

### DIFF
--- a/tools/sumolib/geomhelper.py
+++ b/tools/sumolib/geomhelper.py
@@ -120,11 +120,10 @@ def distancePointToPolygon(point, polygon, perpendicular=False):
 
 
 def positionAtOffset(p1, p2, offset):
-    if offset == 0.:  # for pathological cases with dist == 0 and offset == 0
+    if math.isclose(offset, 0.):  # for pathological cases with dist == 0 and offset == 0
         return p1
     dist = distance(p1, p2)
-    if dist < offset:
-        return None
+    offset = min(dist, offset)
     return (p1[0] + (p2[0] - p1[0]) * (offset / dist), p1[1] + (p2[1] - p1[1]) * (offset / dist))
 
 

--- a/tools/sumolib/geomhelper.py
+++ b/tools/sumolib/geomhelper.py
@@ -122,8 +122,15 @@ def distancePointToPolygon(point, polygon, perpendicular=False):
 def positionAtOffset(p1, p2, offset):
     if math.isclose(offset, 0.):  # for pathological cases with dist == 0 and offset == 0
         return p1
+
     dist = distance(p1, p2)
-    offset = min(dist, offset)
+
+    if math.isclose(dist, offset):
+        return p2
+
+    if offset > dist:
+        return None
+
     return (p1[0] + (p2[0] - p1[0]) * (offset / dist), p1[1] + (p2[1] - p1[1]) * (offset / dist))
 
 


### PR DESCRIPTION

I ran into some floating point math errors while using geomhelpers utilities, modifying the source code to print inputs shows that we are not dealing well with the boundary conditions in some functions:

```python
def positionAtOffset(p1, p2, offset):
    if offset == 0.:  # for pathological cases with dist == 0 and offset == 0
        return p1
    dist = distance(p1, p2)
    if dist < offset:
        print(f"{p1}, {p2}, {offset}, {dist}")
        return None
    return (p1[0] + (p2[0] - p1[0]) * (offset / dist), p1[1] + (p2[1] - p1[1]) * (offset / dist))
```
Gives the following output:
```
(100.0, 0.0), (100.0, 1.6), 1.6000000000000003, 1.6
```
I would be happy to just clip the inputs if I could, but given that `positionAtOffset` is called transitively by other functions in this library, I don't have direct control over the inputs.

This PR just clips the offset to the distance between the two points and also adds a bit more robustness to the `offset == 0` branch by using `math.isclose(offset, 0)`
