### PR TITLE
Fix "static variable should be qualified by type name" javac warnings

### DIFF
--- a/tools/contributed/traas/src/main/java/de/tudresden/sumo/util/Sumo.java
+++ b/tools/contributed/traas/src/main/java/de/tudresden/sumo/util/Sumo.java
@@ -131,7 +131,7 @@ public class Sumo {
     public void start_ws() {
 
         //start SUMO
-        conn = new SumoTraciConnection(conf.sumo_bin, conf.config_file);
+        conn = new SumoTraciConnection(Config.sumo_bin, Config.config_file);
 
         //Add Options
         this.add_options();

--- a/tools/contributed/traas/src/main/java/de/tudresden/ws/ServiceImpl.java
+++ b/tools/contributed/traas/src/main/java/de/tudresden/ws/ServiceImpl.java
@@ -138,7 +138,7 @@ public class ServiceImpl extends Traci implements Service {
     public void setConfig(@WebParam(name = "filename") String filename) {
 
         if (!this.conf.running) {
-            this.conf.config_file = filename;
+            Config.config_file = filename;
         }
 
     }
@@ -148,7 +148,7 @@ public class ServiceImpl extends Traci implements Service {
     public void setSumoBinary(@WebParam(name = "binary") String filename) {
 
         if (!this.conf.running) {
-            this.conf.sumo_bin = filename;
+            Config.sumo_bin = filename;
         }
 
     }


### PR DESCRIPTION
When compiling traas, javac issues 4 errors of the form

```
[static] static variable should be qualified by type name, Config, instead of by an expression
```

This pull request corrects them.
