### PR TITLE
Adding a TraCI-command setPreviousSpeed, see issue #7190

### DIFF
--- a/src/libsumo/TraCIConstants.h
+++ b/src/libsumo/TraCIConstants.h
@@ -832,6 +832,9 @@ TRACI_CONST int VAR_SLOPE = 0x36;
 // speed (get: vehicle)
 TRACI_CONST int VAR_SPEED = 0x40;
 
+// adapt previous speed (set: vehicle)
+TRACI_CONST int VAR_PREV_SPEED = 0x3c;
+
 // lateral speed (get: vehicle)
 TRACI_CONST int VAR_SPEED_LAT = 0x32;
 

--- a/src/libsumo/Vehicle.cpp
+++ b/src/libsumo/Vehicle.cpp
@@ -1421,6 +1421,18 @@ Vehicle::setSpeed(const std::string& vehicleID, double speed) {
 }
 
 void
+Vehicle::setPreviousSpeed(const std::string& vehicleID, double prevspeed) {
+    MSBaseVehicle* vehicle = Helper::getVehicle(vehicleID);
+    MSVehicle* veh = dynamic_cast<MSVehicle*>(vehicle);
+    if (veh == nullptr) {
+        WRITE_WARNING("setPreviousSpeed not yet implemented for meso");
+        return;
+    }
+
+    veh->setPreviousSpeed(prevspeed);
+}
+
+void
 Vehicle::setSpeedMode(const std::string& vehicleID, int speedMode) {
     MSBaseVehicle* vehicle = Helper::getVehicle(vehicleID);
     MSVehicle* veh = dynamic_cast<MSVehicle*>(vehicle);

--- a/src/libsumo/Vehicle.h
+++ b/src/libsumo/Vehicle.h
@@ -166,6 +166,7 @@ public:
     static void deactivateGapControl(const std::string& vehicleID);
     static void requestToC(const std::string& vehID, double leadTime);
     static void setSpeed(const std::string& vehicleID, double speed);
+    static void setPreviousSpeed(const std::string& vehicleID, double prevspeed);
     static void setSpeedMode(const std::string& vehicleID, int speedMode);
     static void setLaneChangeMode(const std::string& vehicleID, int laneChangeMode);
     static void setRoutingMode(const std::string& vehicleID, int routingMode);

--- a/src/microsim/MSVehicle.h
+++ b/src/microsim/MSVehicle.h
@@ -489,6 +489,14 @@ public:
     }
 
 
+    /** @brief Sets the influenced previous speed
+     * @param[in] A double value with the speed that overwrites the previous speed
+     */
+	void setPreviousSpeed(double prevspeed) {
+		myState.mySpeed = MAX2(0., prevspeed);
+	}
+
+
     /** @brief Returns the vehicle's acceleration in m/s
      *         (this is computed as the last step's mean acceleration in case that a stop occurs within the middle of the time-step)
      * @return The acceleration

--- a/src/traci-server/TraCIServerAPI_Vehicle.cpp
+++ b/src/traci-server/TraCIServerAPI_Vehicle.cpp
@@ -417,7 +417,7 @@ TraCIServerAPI_Vehicle::processSet(TraCIServer& server, tcpip::Storage& inputSto
             && variable != libsumo::VAR_APPARENT_DECEL && variable != libsumo::VAR_EMERGENCY_DECEL
             && variable != libsumo::VAR_ACTIONSTEPLENGTH
             && variable != libsumo::VAR_TAU && variable != libsumo::VAR_LANECHANGE_MODE
-            && variable != libsumo::VAR_SPEED && variable != libsumo::VAR_SPEEDSETMODE && variable != libsumo::VAR_COLOR
+            && variable != libsumo::VAR_SPEED && variable != libsumo::VAR_PREV_SPEED && variable != libsumo::VAR_SPEEDSETMODE && variable != libsumo::VAR_COLOR
             && variable != libsumo::ADD && variable != libsumo::ADD_FULL && variable != libsumo::REMOVE
             && variable != libsumo::VAR_HEIGHT
             && variable != libsumo::VAR_ROUTING_MODE
@@ -886,6 +886,14 @@ TraCIServerAPI_Vehicle::processSet(TraCIServer& server, tcpip::Storage& inputSto
                     return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "Setting speed requires a double.", outputStorage);
                 }
                 libsumo::Vehicle::setSpeed(id, speed);
+            }
+            break;
+            case libsumo::VAR_PREV_SPEED: {
+                double prevspeed = 0;
+                if (!server.readTypeCheckingDouble(inputStorage, prevspeed)) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "Setting previous speed requires a double.", outputStorage);
+                }
+                libsumo::Vehicle::setPreviousSpeed(id, prevspeed);
             }
             break;
             case libsumo::VAR_SPEEDSETMODE: {

--- a/src/utils/traci/TraCIAPI.cpp
+++ b/src/utils/traci/TraCIAPI.cpp
@@ -2795,6 +2795,15 @@ TraCIAPI::VehicleScope::setSpeed(const std::string& vehicleID, double speed) con
 }
 
 void
+TraCIAPI::VehicleScope::setPreviousSpeed(const std::string& vehicleID, double prevspeed) const {
+    tcpip::Storage content;
+    content.writeUnsignedByte(libsumo::TYPE_DOUBLE);
+    content.writeDouble(prevspeed);
+    myParent.createCommand(libsumo::CMD_SET_VEHICLE_VARIABLE, libsumo::VAR_PREV_SPEED, vehicleID, &content);
+    myParent.processSet(libsumo::CMD_SET_VEHICLE_VARIABLE);
+}
+
+void
 TraCIAPI::VehicleScope::setLaneChangeMode(const std::string& vehicleID, int mode) const {
     tcpip::Storage content;
     content.writeByte(libsumo::TYPE_INTEGER);
@@ -2851,6 +2860,15 @@ TraCIAPI::VehicleScope::setSpeedFactor(const std::string& vehicleID, double fact
     content.writeUnsignedByte(libsumo::TYPE_DOUBLE);
     content.writeDouble(factor);
     myParent.createCommand(libsumo::CMD_SET_VEHICLE_VARIABLE, libsumo::VAR_SPEED_FACTOR, vehicleID, &content);
+    myParent.processSet(libsumo::CMD_SET_VEHICLE_VARIABLE);
+}
+
+void
+TraCIAPI::VehicleScope::setMinGap(const std::string& vehicleID, double minGap) const {
+    tcpip::Storage content;
+    content.writeUnsignedByte(libsumo::TYPE_DOUBLE);
+    content.writeDouble(minGap);
+    myParent.createCommand(libsumo::CMD_SET_VEHICLE_VARIABLE, libsumo::VAR_MINGAP, vehicleID, &content);
     myParent.processSet(libsumo::CMD_SET_VEHICLE_VARIABLE);
 }
 

--- a/src/utils/traci/TraCIAPI.h
+++ b/src/utils/traci/TraCIAPI.h
@@ -752,6 +752,7 @@ public:
         void slowDown(const std::string& vehicleID, double speed, double duration) const;
         void openGap(const std::string& vehicleID, double newTau, double duration, double changeRate, double maxDecel) const;
         void setSpeed(const std::string& vehicleID, double speed) const;
+        void setPreviousSpeed(const std::string& vehicleID, double prevspeed) const;
         void setLaneChangeMode(const std::string& vehicleID, int mode) const;
         void setSpeedMode(const std::string& vehicleID, int mode) const;
         void setStop(const std::string vehicleID, const std::string edgeID, const double endPos = 1.,
@@ -772,6 +773,7 @@ public:
         void setShapeClass(const std::string& vehicleID, const std::string& clazz) const;
         void setEmissionClass(const std::string& vehicleID, const std::string& clazz) const;
         void setSpeedFactor(const std::string& vehicleID, double factor) const;
+        void setMinGap(const std::string& vehicleID, double minGap) const;
         void setMaxSpeed(const std::string& vehicleID, double speed) const;
         /// @}
 


### PR DESCRIPTION
Signed-off-by: Dominik Salles <dominik.salles@fkfs.de>
I also added the TraCI-command setMinGap for the Vehicle-Class.
I used 0x3c, as I used to have 0x38 for this command, which was taken by now.
This command isn't a fancy implementation, as it only changes mySpeed, but as a few tests showed, it worked good.