### PR TITLE
fix(matsim_importPlans.py): skip persons with zero plans

### DIFF
--- a/tools/import/matsim/matsim_importPlans.py
+++ b/tools/import/matsim/matsim_importPlans.py
@@ -76,7 +76,10 @@ def main(options):
         outf = StringIO()
         vehIndex = 0
         plan = person.plan[0]
-        firstAct = plan.getChildList()[0]
+        try:
+            firstAct = plan.getChildList()[0]
+        except IndexError:
+            continue
         depart = firstAct.start_time
         if depart is None:
             depart = options.defaultStart


### PR DESCRIPTION
Feel free to merge if you think this is useful. I have some people with zero plans in my MATSim plan file which raises `IndexError: list index out of range` error. 