### PR TITLE
added multiprocessing capability to routeSampler.py

### DIFF
--- a/tools/routeSampler.py
+++ b/tools/routeSampler.py
@@ -471,7 +471,7 @@ def main(options):
         sumolib.writeXMLHeader(outf, "$Id$", "routes")  # noqa
         if options.cpuNum > 1:
             # call the multiprocessing function
-            results = multi_process(options.cpuNum, intervals, solveIntervalMP, outf, options=options, routes=routes,
+            results = multi_process(options.cpuNum, intervals, _solveIntervalMP, outf, options=options, routes=routes,
                                     mismatchf=mismatchf)
             # handle the uFlow, oFlow and GEH
             for _, result in results:
@@ -482,7 +482,7 @@ def main(options):
         else:
             for begin, end in intervals:
                 intervalPrefix = "" if len(intervals) == 1 else "%s_" % int(begin)
-                uFlow, oFlow, gehOK = solveInterval(options, routes, begin, end, intervalPrefix, outf, mismatchf)
+                uFlow, oFlow, gehOK, _ = solveInterval(options, routes, begin, end, intervalPrefix, outf, mismatchf)
                 underflowSummary.add(uFlow, begin)
                 overflowSummary.add(oFlow, begin)
                 gehSummary.add(gehOK, begin)
@@ -503,211 +503,16 @@ def _sample(sampleSet):
     return population[(int)(random.random() * len(population))]
 
 
-def solveIntervalMP(options, routes, interval, mismatchf):
-    # store which routes are passing each counting location (using route index)
-
-    """ solveInterval is assigned to each pool worker and is passed a list of (begin, end).
-    added a for loop to process all intervals passed. Instead of directly writing the to the route file,
-    it returns a list of lines to write. multiprocessing doesn't like sharing a file write object between workers"""
-
-    outf = []
-    underflow_lst = []
-    overflow_lst = []
-    geh_lst = []
-    time_lst = []
-
+def _solveIntervalMP(options, routes, interval, mismatchf):
+    output_list = []
     for begin, end in interval:
-
-        print(begin, end)
-
+        local_outf = StringIO()
         intervalPrefix = "%s_" % int(begin)
+        uFlow, oFlow, gehOKNum, local_outf = solveInterval(options, routes, begin, end, intervalPrefix, local_outf, mismatchf)
+        output_list.append([begin, uFlow, oFlow, gehOKNum, local_outf.getvalue()])
+    output_lst = list(zip(*output_list))
+    return output_lst[0], output_lst[1], output_lst[2], output_lst[3], output_lst[4]
 
-        countData = (parseDataIntervals(parseTurnCounts, options.turnFiles, begin, end, routes, options.turnAttr,
-                                        options=options)
-                     + parseDataIntervals(parseEdgeCounts, options.edgeDataFiles, begin, end, routes,
-                                          options.edgeDataAttr,
-                                          options=options)
-                     + parseDataIntervals(parseTurnCounts, options.odFiles, begin, end, routes, options.turnAttr,
-                                          isOD=True,
-                                          options=options)
-                     )
-
-        routeUsage = getRouteUsage(routes, countData)
-
-        # pick a random couting location and select a new route that passes it until
-        # all counts are satisfied or no routes can be used anymore
-        openRoutes = set(range(0, routes.number))
-        openCounts = set(range(0, len(countData)))
-        openRoutes = updateOpenRoutes(openRoutes, routeUsage, countData)
-        openCounts = updateOpenCounts(openCounts, countData, openRoutes)
-
-        usedRoutes = []
-        if options.optimizeInput:
-            usedRoutes = [routes.edges2index[e] for e in routes.all]
-            resetCounts(usedRoutes, routeUsage, countData)
-        else:
-            while openCounts:
-                cd = countData[_sample(openCounts)]
-                routeIndex = _sample(cd.routeSet.intersection(openRoutes))
-                usedRoutes.append(routeIndex)
-                for dataIndex in routeUsage[routeIndex]:
-                    countData[dataIndex].count -= 1
-                openRoutes = updateOpenRoutes(openRoutes, routeUsage, countData)
-                openCounts = updateOpenCounts(openCounts, countData, openRoutes)
-
-        totalMismatch = sum([cd.count for cd in countData])
-        if totalMismatch > 0 and options.optimize is not None:
-            if options.verbose:
-                print("Starting optimization for interval [%s, %s] (mismatch %s)" % (
-                    begin, end, totalMismatch))
-            optimize(options, countData, routes, usedRoutes, routeUsage)
-            resetCounts(usedRoutes, routeUsage, countData)
-        # avoid bias from sampling order / optimization
-        random.shuffle(usedRoutes, random.random)
-
-        if usedRoutes:
-            outf.append('<!-- begin="%s" end="%s" -->\n' % (begin, end))
-            period = (end - begin) / len(usedRoutes)
-            depart = begin
-            routeCounts = getRouteCounts(routes, usedRoutes)
-            if options.writeRouteIDs:
-                for routeIndex in sorted(set(usedRoutes)):
-                    outf.append('    <route id="%s%s" edges="%s"/> <!-- %s -->\n' % (
-                        intervalPrefix, routeIndex, ' '.join(routes.unique[routeIndex]), routeCounts[routeIndex]))
-                outf.append('\n')
-            elif options.writeRouteDist:
-                outf.append('    <routeDistribution id="%s%s"/>\n' % (intervalPrefix, options.writeRouteDist))
-                for routeIndex in sorted(set(usedRoutes)):
-                    outf.append('        <route id="%s%s" edges="%s" probability="%s"/>\n' % (
-                        intervalPrefix, routeIndex, ' '.join(routes.unique[routeIndex]), routeCounts[routeIndex]))
-                outf.append('    </routeDistribution>\n\n')
-
-            routeID = options.writeRouteDist
-            if options.writeFlows is None:
-                for i, routeIndex in enumerate(usedRoutes):
-                    if options.writeRouteIDs:
-                        routeID = routeIndex
-                    vehID = options.prefix + intervalPrefix + str(i)
-                    if routeID is not None:
-                        outf.append('    <vehicle id="%s" depart="%.2f" route="%s%s"%s/>\n' % (
-                            vehID, depart, intervalPrefix, routeID, options.vehattrs))
-                    else:
-                        outf.append('    <vehicle id="%s" depart="%.2f"%s>\n' % (
-                            vehID, depart, options.vehattrs))
-                        outf.append('        <route edges="%s"/>\n' % ' '.join(routes.unique[routeIndex]))
-                        outf.append('    </vehicle>\n')
-                    depart += period
-            else:
-                routeDeparts = defaultdict(list)
-                for routeIndex in usedRoutes:
-                    routeDeparts[routeIndex].append(depart)
-                    depart += period
-                if options.writeRouteDist:
-                    totalCount = sum(routeCounts)
-                    probability = totalCount / (end - begin)
-                    flowID = options.prefix + intervalPrefix + options.writeRouteDist
-                    if options.writeFlows == "number" or probability > 1.001:
-                        repeat = 'number="%s"' % totalCount
-                        if options.writeFlows == "probability":
-                            sys.stderr.write("Warning: could not write flow %s with probability %.2f\n" %
-                                             (flowID, probability))
-                    else:
-                        repeat = 'probability="%s"' % probability
-                    outf.write('    <flow id="%s" begin="%.2f" end="%.2f" %s route="%s"%s/>\n' % (
-                        flowID, begin, end, repeat,
-                        options.writeRouteDist, options.vehattrs))
-                else:
-                    # ensure flows are sorted
-                    flows = []
-                    for routeIndex in sorted(set(usedRoutes)):
-                        outf2 = StringIO()
-                        fBegin = min(routeDeparts[routeIndex])
-                        fEnd = max(routeDeparts[routeIndex] + [fBegin + 1.0])
-                        probability = routeCounts[routeIndex] / (fEnd - fBegin)
-                        flowID = "%s%s%s" % (options.prefix, intervalPrefix, routeIndex)
-                        if options.writeFlows == "number" or probability > 1.001:
-                            repeat = 'number="%s"' % routeCounts[routeIndex]
-                            if options.writeFlows == "probability":
-                                sys.stderr.write("Warning: could not write flow %s with probability %.2f\n" % (
-                                    flowID, probability))
-                        else:
-                            repeat = 'probability="%s"' % probability
-                        if options.writeRouteIDs:
-                            outf2.write('    <flow id="%s" begin="%.2f" end="%.2f" %s route="%s%s"%s/>\n' % (
-                                flowID, fBegin, fEnd, repeat,
-                                intervalPrefix, routeIndex, options.vehattrs))
-                        else:
-                            outf2.write('    <flow id="%s" begin="%.2f" end="%.2f" %s%s>\n' % (
-                                flowID, fBegin, fEnd, repeat, options.vehattrs))
-                            outf2.write('        <route edges="%s"/>\n' % ' '.join(routes.unique[routeIndex]))
-                            outf2.write('    </flow>\n')
-                        flows.append((fBegin, outf2))
-                    flows.sort()
-                    for fBegin, outf2 in flows:
-                        outf.append(outf2.getvalue())
-
-        underflow = sumolib.miscutils.Statistics("underflow locations")
-        overflow = sumolib.miscutils.Statistics("overflow locations")
-        gehStats = sumolib.miscutils.Statistics("GEH")
-        numGehOK = 0.0
-        hourFraction = (end - begin) / 3600.0
-        totalCount = 0
-        for cd in countData:
-            localCount = cd.origCount - cd.count
-            totalCount += localCount
-            if cd.count > 0:
-                underflow.add(cd.count, cd.edgeTuple)
-            elif cd.count < 0:
-                overflow.add(cd.count, cd.edgeTuple)
-            origHourly = cd.origCount / hourFraction
-            localHourly = localCount / hourFraction
-            geh = sumolib.miscutils.geh(origHourly, localHourly)
-            if geh < options.gehOk:
-                numGehOK += 1
-            gehStats.add(geh, "[%s] %s %s" % (
-                ' '.join(cd.edgeTuple), int(origHourly), int(localHourly)))
-
-        outputIntervalPrefix = "" if intervalPrefix == "" else "%s: " % int(begin)
-        gehOKNum = (100 * numGehOK / len(countData)) if countData else 100
-        gehOK = "%.2f%%" % gehOKNum if countData else "-"
-        print("%sWrote %s routes (%s distinct) achieving total count %s at %s locations. GEH<%s for %s" % (
-            outputIntervalPrefix,
-            len(usedRoutes), len(set(usedRoutes)), totalCount, len(countData),
-            options.gehOk, gehOK))
-
-        if options.verboseHistogram:
-            edgeCount = sumolib.miscutils.Statistics("route edge count", histogram=True)
-            detectorCount = sumolib.miscutils.Statistics("route detector count", histogram=True)
-            for i, r in enumerate(usedRoutes):
-                edgeCount.add(len(routes.unique[r]), i)
-                detectorCount.add(len(routeUsage[r]), i)
-            print("result %s" % edgeCount)
-            print("result %s" % detectorCount)
-            print(gehStats)
-
-        if underflow.count() > 0:
-            print("Warning: %s (total %s)" % (underflow, sum(underflow.values)))
-        if overflow.count() > 0:
-            print("Warning: %s (total %s)" % (overflow, sum(overflow.values)))
-
-        if mismatchf:
-            mismatchf.write('    <interval id="deficit" begin="%s" end="%s">\n' % (begin, end))
-            for cd in countData:
-                if len(cd.edgeTuple) == 1:
-                    mismatchf.write('        <edge id="%s" measuredCount="%s" deficit="%s"/>\n' % (
-                        cd.edgeTuple[0], cd.origCount, cd.count))
-                elif len(cd.edgeTuple) == 2:
-                    mismatchf.write('        <edgeRelation from="%s" to="%s" measuredCount="%s" deficit="%s"/>\n' % (
-                        cd.edgeTuple[0], cd.edgeTuple[1], cd.origCount, cd.count))
-                else:
-                    print("Warning: output for edge relations with more than 2 edges not supported (%s)" % cd.edgeTuple,
-                          file=sys.stderr)
-            mismatchf.write('    </interval>\n')
-        time_lst.append(begin)
-        underflow_lst.append(sum(underflow.values))
-        overflow_lst.append(sum(overflow.values))
-        geh_lst.append(gehOKNum)
-    return time_lst, underflow_lst, overflow_lst, geh_lst, outf
 
 def solveInterval(options, routes, begin, end, intervalPrefix, outf, mismatchf):
     # store which routes are passing each counting location (using route index)
@@ -893,7 +698,7 @@ def solveInterval(options, routes, begin, end, intervalPrefix, outf, mismatchf):
                       file=sys.stderr)
         mismatchf.write('    </interval>\n')
 
-    return sum(underflow.values), sum(overflow.values), gehOKNum
+    return sum(underflow.values), sum(overflow.values), gehOKNum, outf
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We are frequently working with >= 24 hour data that we aggregate into 120 second intervals. Because of the large number of intervals, routeSampler is the longest running process in our workflow. I added multiprocessing capability to the routeSampler and drastically reduced its compute time.

I haven't tested with all combinations of option inputs, so this probably isn't "release" ready. It works for our purposes though so thought that I would share.   

As it stands, multiprocessing will not work with the mismatch-output option. 

Signed-off-by: Maxwell Schrader <mcschrader@crimson.ua.edu>