### PR TITLE
Remove sys.exit(1) on successful completion

### DIFF
--- a/tools/generateContinuousRerouters.py
+++ b/tools/generateContinuousRerouters.py
@@ -175,5 +175,4 @@ def main(options):
 
 
 if __name__ == "__main__":
-    if not main(get_options()):
-        sys.exit(1)
+    main(get_options())


### PR DESCRIPTION
This is a proposed solution to #7722 

Signed-off-by: Hoxovic <fredrik.hoxell@gmail.com>