### PR TITLE
Compile Java classes for libsumojni.jar and libtracijni.jar with target version 1.7

### DIFF
--- a/src/libsumo/CMakeLists.txt
+++ b/src/libsumo/CMakeLists.txt
@@ -99,7 +99,7 @@ if(SWIG_FOUND)
 				COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/LICENSE java/META-INF
 				COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/NOTICE.md classes/META-INF
 				COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/LICENSE classes/META-INF
-                COMMAND "${Java_JAVAC_EXECUTABLE}" -source 1.8 -target 1.8 -d classes java/*.java
+                COMMAND "${Java_JAVAC_EXECUTABLE}" -source 1.7 -target 1.7 -d classes java/*.java
                 COMMAND "${Java_JAR_EXECUTABLE}" -cfM ${CMAKE_SOURCE_DIR}/bin/libsumojni.jar -C classes .
                 COMMAND "${Java_JAR_EXECUTABLE}" -cfM ${CMAKE_SOURCE_DIR}/bin/libsumojni_src.jar -C java .
             )

--- a/src/libsumo/CMakeLists.txt
+++ b/src/libsumo/CMakeLists.txt
@@ -99,7 +99,7 @@ if(SWIG_FOUND)
 				COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/LICENSE java/META-INF
 				COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/NOTICE.md classes/META-INF
 				COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/LICENSE classes/META-INF
-                COMMAND "${Java_JAVAC_EXECUTABLE}" -d classes java/*.java
+                COMMAND "${Java_JAVAC_EXECUTABLE}" -source 1.8 -target 1.8 -d classes java/*.java
                 COMMAND "${Java_JAR_EXECUTABLE}" -cfM ${CMAKE_SOURCE_DIR}/bin/libsumojni.jar -C classes .
                 COMMAND "${Java_JAR_EXECUTABLE}" -cfM ${CMAKE_SOURCE_DIR}/bin/libsumojni_src.jar -C java .
             )

--- a/src/libtraci/CMakeLists.txt
+++ b/src/libtraci/CMakeLists.txt
@@ -76,7 +76,7 @@ if(SWIG_FOUND)
 				COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/LICENSE java/META-INF
 				COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/NOTICE.md classes/META-INF
 				COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_SOURCE_DIR}/LICENSE classes/META-INF
-                COMMAND "${Java_JAVAC_EXECUTABLE}" -d classes java/*.java
+                COMMAND "${Java_JAVAC_EXECUTABLE}" -source 1.7 -target 1.7 -d classes java/*.java
                 COMMAND "${Java_JAR_EXECUTABLE}" -cfM ${CMAKE_SOURCE_DIR}/bin/libtracijni.jar -C classes .
                 COMMAND "${Java_JAR_EXECUTABLE}" -cfM ${CMAKE_SOURCE_DIR}/bin/libtracijni_src.jar -C java .
             )


### PR DESCRIPTION
The libsumojni.jar should be compatible with as many Java versions as possible. Currently this is not the case, as the target version of the compiled classes are not defined, making it dependent on the compiler used during the build. As a result, previous versions of libsumojni.jar had different major versions: in 1.7.0 it was build with a Java 8 compiler, in 1.8.0 with an Java 11 compiler, and in the nightly master builds currently uses a Java 15 compiler. However, one could simply define the target version during compiling the classes by using `-target` parameter.

We should not use the new parameter `--release`, as this is only available since JDK 9 but some linux builds still use JDK8. See discussion in #7989 . 

This PR replaces #7989 which has been messed up by myself 🤦🏻 

Signed-off-by: Karl Schrab <karl.schrab@fokus.fraunhofer.de>