### PR TITLE
Adding TransportableState and getDepartedPerson and getArrivedPerson commands

### DIFF
--- a/src/libsumo/Helper.h
+++ b/src/libsumo/Helper.h
@@ -175,6 +175,12 @@ public:
 
     static void clearVehicleStates();
 
+    static void registerTransportableStateListener();
+
+    static const std::vector<std::string>& getTransportableStateChanges(const MSNet::TransportableState state);
+
+    static void clearTransportableStates();
+
     /// @name functions for moveToXY
     /// @{
     static bool moveToXYMap(const Position& pos, double maxRouteDistance, bool mayLeaveNetwork, const std::string& origID,
@@ -252,6 +258,13 @@ private:
         std::map<MSNet::VehicleState, std::vector<std::string> > myVehicleStateChanges;
     };
 
+    class TransportableStateListener : public MSNet::TransportableStateListener {
+    public:
+        void transportableStateChanged(const MSTransportable* const transportable, MSNet::TransportableState to, const std::string& info = "");
+        /// @brief Changes in the states of simulated transportables
+        std::map<MSNet::TransportableState, std::vector<std::string> > myTransportableStateChanges;
+    };
+
     /// @brief The list of known, still valid subscriptions
     static std::vector<Subscription> mySubscriptions;
 
@@ -263,6 +276,9 @@ private:
 
     /// @brief Changes in the states of simulated vehicles
     static VehicleStateListener myVehicleStateListener;
+
+    /// @brief Changes in the states of simulated transportables
+    static TransportableStateListener myTransportableStateListener;
 
     /// @brief A storage of lanes
     static LANE_RTREE_QUAL* myLaneTree;

--- a/src/libsumo/Simulation.cpp
+++ b/src/libsumo/Simulation.cpp
@@ -94,6 +94,7 @@ Simulation::isLoaded() {
 void
 Simulation::step(const double time) {
     Helper::clearVehicleStates();
+    Helper::clearTransportableStates();
     const SUMOTime t = TIME2STEPS(time);
     if (t == 0) {
         MSNet::getInstance()->simulationStep();
@@ -289,6 +290,29 @@ Simulation::getEndingTeleportNumber() {
 std::vector<std::string>
 Simulation::getEndingTeleportIDList() {
     return Helper::getVehicleStateChanges(MSNet::VehicleState::ENDING_TELEPORT);
+}
+
+int
+Simulation::getDepartedPersonNumber() {
+    return (int)Helper::getTransportableStateChanges(MSNet::TransportableState::PERSON_DEPARTED).size();
+}
+
+
+std::vector<std::string>
+Simulation::getDepartedPersonIDList() {
+    return Helper::getTransportableStateChanges(MSNet::TransportableState::PERSON_DEPARTED);
+}
+
+
+int
+Simulation::getArrivedPersonNumber() {
+    return (int)Helper::getTransportableStateChanges(MSNet::TransportableState::PERSON_ARRIVED).size();
+}
+
+
+std::vector<std::string>
+Simulation::getArrivedPersonIDList() {
+    return Helper::getTransportableStateChanges(MSNet::TransportableState::PERSON_ARRIVED);
 }
 
 std::vector<std::string>
@@ -767,6 +791,7 @@ Simulation::loadState(const std::string& fileName) {
         throw TraCIException("Loading state from '" + fileName + "' failed.");
     }
     Helper::clearVehicleStates();
+    Helper::clearTransportableStates();
     PROGRESS_TIME_MESSAGE(before);
     return STEPS2TIME(newTime);
 }
@@ -834,6 +859,14 @@ Simulation::handleVariable(const std::string& objID, const int variable, Variabl
             return wrapper->wrapInt(objID, variable, getEmergencyStoppingVehiclesNumber());
         case VAR_EMERGENCYSTOPPING_VEHICLES_IDS:
             return wrapper->wrapStringList(objID, variable, getEmergencyStoppingVehiclesIDList());
+        case VAR_DEPARTED_PERSONS_NUMBER:
+            return wrapper->wrapInt(objID, variable, getDepartedPersonNumber());
+        case VAR_DEPARTED_PERSONS_IDS:
+            return wrapper->wrapStringList(objID, variable, getDepartedPersonIDList());
+        case VAR_ARRIVED_PERSONS_NUMBER:
+            return wrapper->wrapInt(objID, variable, getArrivedPersonNumber());
+        case VAR_ARRIVED_PERSONS_IDS:
+            return wrapper->wrapStringList(objID, variable, getArrivedPersonIDList());
         case VAR_DELTA_T:
             return wrapper->wrapDouble(objID, variable, getDeltaT());
         case VAR_MIN_EXPECTED_VEHICLES:

--- a/src/libsumo/Simulation.h
+++ b/src/libsumo/Simulation.h
@@ -94,6 +94,11 @@ public:
     static int getEndingTeleportNumber();
     static std::vector<std::string> getEndingTeleportIDList();
 
+    static int getDepartedPersonNumber();
+    static std::vector<std::string> getDepartedPersonIDList();
+    static int getArrivedPersonNumber();
+    static std::vector<std::string> getArrivedPersonIDList();
+
     static std::vector<std::string> getBusStopIDList();
     static int getBusStopWaiting(const std::string& stopID);
 

--- a/src/libsumo/TraCIConstants.h
+++ b/src/libsumo/TraCIConstants.h
@@ -1142,6 +1142,18 @@ TRACI_CONST int VAR_NET_BOUNDING_BOX = 0x7c;
 // minimum number of expected vehicles (get: simulation)
 TRACI_CONST int VAR_MIN_EXPECTED_VEHICLES = 0x7d;
 
+// number of departed persons (get: simulation)
+TRACI_CONST int VAR_DEPARTED_PERSONS_NUMBER = 0x60;
+
+// departed person ids (get: simulation)
+TRACI_CONST int VAR_DEPARTED_PERSONS_IDS = 0x61;
+
+// number of arrived persons (get: simulation)
+TRACI_CONST int VAR_ARRIVED_PERSONS_NUMBER = 0x62;
+
+// ids of arrived persons (get: simulation)
+TRACI_CONST int VAR_ARRIVED_PERSONS_IDS = 0x63;
+
 // number of vehicles starting to park (get: simulation)
 TRACI_CONST int VAR_STOP_STARTING_VEHICLES_NUMBER = 0x68;
 

--- a/src/libtraci/Simulation.cpp
+++ b/src/libtraci/Simulation.cpp
@@ -282,6 +282,30 @@ Simulation::getEndingTeleportIDList() {
 }
 
 
+int
+Simulation::getDepartedPersonNumber() {
+    return Dom::getInt(libsumo::VAR_DEPARTED_PERSONS_NUMBER, "");
+}
+
+
+std::vector<std::string>
+Simulation::getDepartedPersonIDList() {
+    return Dom::getStringVector(libsumo::VAR_DEPARTED_PERSONS_IDS, "");
+}
+
+
+int
+Simulation::getArrivedPersonNumber() {
+    return Dom::getInt(libsumo::VAR_ARRIVED_PERSONS_NUMBER, "");
+}
+
+
+std::vector<std::string>
+Simulation::getArrivedPersonIDList() {
+    return Dom::getStringVector(libsumo::VAR_ARRIVED_PERSONS_IDS, "");
+}
+
+
 std::vector<std::string>
 Simulation::getBusStopIDList() {
     return Dom::getStringVector(libsumo::VAR_BUS_STOP_ID_LIST, "");

--- a/src/microsim/MSNet.cpp
+++ b/src/microsim/MSNet.cpp
@@ -1101,12 +1101,41 @@ MSNet::removeVehicleStateListener(VehicleStateListener* listener) {
 void
 MSNet::informVehicleStateListener(const SUMOVehicle* const vehicle, VehicleState to, const std::string& info) {
 #ifdef HAVE_FOX
-    FXConditionalLock lock(myStateListenerMutex, MSGlobals::gNumThreads > 1);
+    FXConditionalLock lock(myVehicleStateListenerMutex, MSGlobals::gNumThreads > 1);
 #endif
     for (VehicleStateListener* const listener : myVehicleStateListeners) {
         listener->vehicleStateChanged(vehicle, to, info);
     }
 }
+
+
+void
+MSNet::addTransportableStateListener(TransportableStateListener* listener) {
+    if (find(myTransportableStateListeners.begin(), myTransportableStateListeners.end(), listener) == myTransportableStateListeners.end()) {
+        myTransportableStateListeners.push_back(listener);
+    }
+}
+
+
+void
+MSNet::removeTransportableStateListener(TransportableStateListener* listener) {
+    std::vector<TransportableStateListener*>::iterator i = std::find(myTransportableStateListeners.begin(), myTransportableStateListeners.end(), listener);
+    if (i != myTransportableStateListeners.end()) {
+        myTransportableStateListeners.erase(i);
+    }
+}
+
+
+void
+MSNet::informTransportableStateListener(const MSTransportable* const transportable, TransportableState to, const std::string& info) {
+#ifdef HAVE_FOX
+    FXConditionalLock lock(myTransportableStateListenerMutex, MSGlobals::gNumThreads > 1);
+#endif
+    for (TransportableStateListener* const listener : myTransportableStateListeners) {
+        listener->transportableStateChanged(transportable, to, info);
+    }
+}
+
 
 bool
 MSNet::registerCollision(const SUMOTrafficObject* collider, const SUMOTrafficObject* victim, const std::string& collisionType, const MSLane* lane, double pos) {
@@ -1130,6 +1159,7 @@ MSNet::registerCollision(const SUMOTrafficObject* collider, const SUMOTrafficObj
     myCollisions[collider->getID()].push_back(c);
     return true;
 }
+
 
 bool
 MSNet::addStoppingPlace(const SumoXMLTag category, MSStoppingPlace* stop) {

--- a/src/microsim/transportables/MSTransportableControl.cpp
+++ b/src/microsim/transportables/MSTransportableControl.cpp
@@ -123,6 +123,11 @@ MSTransportableControl::erase(MSTransportable* transportable) {
     const std::map<std::string, MSTransportable*>::iterator i = myTransportables.find(transportable->getID());
     if (i != myTransportables.end()) {
         myRunningNumber--;
+        if (transportable->isPerson()) {
+            MSNet::getInstance()->informTransportableStateListener(transportable, MSNet::TransportableState::PERSON_ARRIVED);
+        } else {
+            MSNet::getInstance()->informTransportableStateListener(transportable, MSNet::TransportableState::CONTAINER_ARRIVED);
+        }
         myEndedNumber++;
         delete i->second;
         myTransportables.erase(i);
@@ -152,6 +157,12 @@ MSTransportableControl::checkWaiting(MSNet* net, const SUMOTime time) {
             myWaitingForDepartureNumber--;
             if (transportables[i]->proceed(net, time)) {
                 myRunningNumber++;
+                if (transportables[i]->isPerson()) {
+                    MSNet::getInstance()->informTransportableStateListener(transportables[i], MSNet::TransportableState::PERSON_DEPARTED);
+                }
+                else {
+                    MSNet::getInstance()->informTransportableStateListener(transportables[i], MSNet::TransportableState::CONTAINER_DEPARTED);
+                }
             } else {
                 erase(transportables[i]);
             }

--- a/src/traci-server/TraCIServer.cpp
+++ b/src/traci-server/TraCIServer.cpp
@@ -239,6 +239,11 @@ TraCIServer::TraCIServer(const SUMOTime begin, const int port, const int numClie
     myVehicleStateChanges[MSNet::VehicleState::COLLISION] = std::vector<std::string>();
     myVehicleStateChanges[MSNet::VehicleState::EMERGENCYSTOP] = std::vector<std::string>();
 
+    myTransportableStateChanges[MSNet::TransportableState::PERSON_DEPARTED] = std::vector<std::string>();
+    myTransportableStateChanges[MSNet::TransportableState::PERSON_ARRIVED] = std::vector<std::string>();
+    myTransportableStateChanges[MSNet::TransportableState::CONTAINER_DEPARTED] = std::vector<std::string>();
+    myTransportableStateChanges[MSNet::TransportableState::CONTAINER_ARRIVED] = std::vector<std::string>();
+
     myExecutors[libsumo::CMD_GET_INDUCTIONLOOP_VARIABLE] = &TraCIServerAPI_InductionLoop::processGet;
     myExecutors[libsumo::CMD_SET_INDUCTIONLOOP_VARIABLE] = &TraCIServerAPI_InductionLoop::processSet;
     myExecutors[libsumo::CMD_GET_LANEAREA_VARIABLE] = &TraCIServerAPI_LaneArea::processGet;
@@ -323,6 +328,11 @@ TraCIServer::TraCIServer(const SUMOTime begin, const int port, const int numClie
             mySockets[index]->vehicleStateChanges[MSNet::VehicleState::ENDING_STOP] = std::vector<std::string>();
             mySockets[index]->vehicleStateChanges[MSNet::VehicleState::COLLISION] = std::vector<std::string>();
             mySockets[index]->vehicleStateChanges[MSNet::VehicleState::EMERGENCYSTOP] = std::vector<std::string>();
+
+            mySockets[index]->transportableStateChanges[MSNet::TransportableState::PERSON_DEPARTED] = std::vector<std::string>();
+            mySockets[index]->transportableStateChanges[MSNet::TransportableState::PERSON_ARRIVED] = std::vector<std::string>();
+            mySockets[index]->transportableStateChanges[MSNet::TransportableState::CONTAINER_DEPARTED] = std::vector<std::string>();
+            mySockets[index]->transportableStateChanges[MSNet::TransportableState::CONTAINER_ARRIVED] = std::vector<std::string>();
             if (numClients > 1) {
                 WRITE_MESSAGE("  client connected");
             }
@@ -361,6 +371,7 @@ TraCIServer::openSocket(const std::map<int, CmdExecutor>& execs) {
     if (myInstance != nullptr) {
         // maybe net was deleted and built again
         MSNet::getInstance()->addVehicleStateListener(myInstance);
+        MSNet::getInstance()->addTransportableStateListener(myInstance);
         myInstance->mySubscriptionCache.writeInt(0);
     }
 }
@@ -392,6 +403,17 @@ TraCIServer::vehicleStateChanged(const SUMOVehicle* const vehicle, MSNet::Vehicl
         myVehicleStateChanges[to].push_back(vehicle->getID());
         for (std::map<int, SocketInfo*>::iterator i = mySockets.begin(); i != mySockets.end(); ++i) {
             i->second->vehicleStateChanges[to].push_back(vehicle->getID());
+        }
+    }
+}
+
+
+void
+TraCIServer::transportableStateChanged(const MSTransportable* const transportable, MSNet::TransportableState to, const std::string& /*info*/) {
+    if (!myDoCloseConnection) {
+        myTransportableStateChanges[to].push_back(transportable->getID());
+        for (std::map<int, SocketInfo*>::iterator i = mySockets.begin(); i != mySockets.end(); ++i) {
+            i->second->transportableStateChanges[to].push_back(transportable->getID());
         }
     }
 }
@@ -662,10 +684,14 @@ TraCIServer::processCommandsUntilSimStep(SUMOTime step) {
                     }
                 }
                 if (done) {
-                    // Clear vehicleStateChanges for this client -> For subsequent TraCI stepping
+                    // Clear vehicleStateChanges and transportableStateChanges for this client
+                    // -> For subsequent TraCI stepping
                     // that is performed within this SUMO step, no updates on vehicle states
                     // belonging to the last SUMO simulation step will be received by this client.
                     for (std::map<MSNet::VehicleState, std::vector<std::string> >::iterator i = myCurrentSocket->second->vehicleStateChanges.begin(); i != myCurrentSocket->second->vehicleStateChanges.end(); ++i) {
+                        (*i).second.clear();
+                    }
+                    for (std::map<MSNet::TransportableState, std::vector<std::string> >::iterator i = myCurrentSocket->second->transportableStateChanges.begin(); i != myCurrentSocket->second->transportableStateChanges.end(); ++i) {
                         (*i).second.clear();
                     }
                     myCurrentSocket++;
@@ -698,8 +724,11 @@ TraCIServer::processCommandsUntilSimStep(SUMOTime step) {
             myTargetTime = nextT;
         }
         // All clients are done with the current time step
-        // Reset myVehicleStateChanges
+        // Reset myVehicleStateChanges and myTransportableStateChanges
         for (std::map<MSNet::VehicleState, std::vector<std::string> >::iterator i = myVehicleStateChanges.begin(); i != myVehicleStateChanges.end(); ++i) {
+            (*i).second.clear();
+        }
+        for (std::map<MSNet::TransportableState, std::vector<std::string> >::iterator i = myTransportableStateChanges.begin(); i != myTransportableStateChanges.end(); ++i) {
             (*i).second.clear();
         }
     } catch (std::invalid_argument& e) {
@@ -725,6 +754,9 @@ TraCIServer::cleanup() {
     std::map<MSNet::VehicleState, std::vector<std::string> >::iterator i;
     for (i = myVehicleStateChanges.begin(); i != myVehicleStateChanges.end(); i++) {
         i->second.clear();
+    }
+    for (std::map<MSNet::TransportableState, std::vector<std::string> >::iterator i = myTransportableStateChanges.begin(); i != myTransportableStateChanges.end(); ++i) {
+        (*i).second.clear();
     }
     myCurrentSocket = mySockets.begin();
 }
@@ -956,7 +988,8 @@ TraCIServer::postProcessSimulationStep() {
         const libsumo::Subscription& s = *i;
         bool isArrivedVehicle = (s.commandId == libsumo::CMD_SUBSCRIBE_VEHICLE_VARIABLE || s.commandId == libsumo::CMD_SUBSCRIBE_VEHICLE_CONTEXT)
                                 && (find(myVehicleStateChanges[MSNet::VehicleState::ARRIVED].begin(), myVehicleStateChanges[MSNet::VehicleState::ARRIVED].end(), s.id) != myVehicleStateChanges[MSNet::VehicleState::ARRIVED].end());
-        bool isArrivedPerson = (s.commandId == libsumo::CMD_SUBSCRIBE_PERSON_VARIABLE || s.commandId == libsumo::CMD_SUBSCRIBE_PERSON_CONTEXT) && MSNet::getInstance()->getPersonControl().get(s.id) == nullptr;
+        bool isArrivedPerson = (s.commandId == libsumo::CMD_SUBSCRIBE_PERSON_VARIABLE || s.commandId == libsumo::CMD_SUBSCRIBE_PERSON_CONTEXT)
+                                && (find(myTransportableStateChanges[MSNet::TransportableState::PERSON_ARRIVED].begin(), myTransportableStateChanges[MSNet::TransportableState::PERSON_ARRIVED].end(), s.id) != myTransportableStateChanges[MSNet::TransportableState::PERSON_ARRIVED].end());
         if ((s.endTime < t) || isArrivedVehicle || isArrivedPerson) {
             i = mySubscriptions.erase(i);
             continue;
@@ -1601,6 +1634,9 @@ TraCIServer::stateLoaded(SUMOTime targetTime) {
     for (auto& s : mySockets) {
         s.second->targetTime = targetTime;
         for (auto& stateChange : s.second->vehicleStateChanges) {
+            stateChange.second.clear();
+        }
+        for (auto& stateChange : s.second->transportableStateChanges) {
             stateChange.second.clear();
         }
     }

--- a/src/traci-server/TraCIServerAPI_Simulation.cpp
+++ b/src/traci-server/TraCIServerAPI_Simulation.cpp
@@ -82,6 +82,18 @@ TraCIServerAPI_Simulation::processGet(TraCIServer& server, tcpip::Storage& input
             case libsumo::VAR_ARRIVED_VEHICLES_IDS:
                 writeVehicleStateIDs(server, server.getWrapperStorage(), MSNet::VehicleState::ARRIVED);
                 break;
+            case libsumo::VAR_DEPARTED_PERSONS_NUMBER:
+                writeTransportableStateNumber(server, server.getWrapperStorage(), MSNet::TransportableState::PERSON_DEPARTED);
+                break;
+            case libsumo::VAR_DEPARTED_PERSONS_IDS:
+                writeTransportableStateIDs(server, server.getWrapperStorage(), MSNet::TransportableState::PERSON_DEPARTED);
+                break;
+            case libsumo::VAR_ARRIVED_PERSONS_NUMBER:
+                writeTransportableStateNumber(server, server.getWrapperStorage(), MSNet::TransportableState::PERSON_ARRIVED);
+                break;
+            case libsumo::VAR_ARRIVED_PERSONS_IDS:
+                writeTransportableStateIDs(server, server.getWrapperStorage(), MSNet::TransportableState::PERSON_ARRIVED);
+                break;
             case libsumo::VAR_PARKING_STARTING_VEHICLES_NUMBER:
                 writeVehicleStateNumber(server, server.getWrapperStorage(), MSNet::VehicleState::STARTING_PARKING);
                 break;
@@ -370,6 +382,22 @@ TraCIServerAPI_Simulation::writeVehicleStateNumber(TraCIServer& server, tcpip::S
 void
 TraCIServerAPI_Simulation::writeVehicleStateIDs(TraCIServer& server, tcpip::Storage& outputStorage, MSNet::VehicleState state) {
     const std::vector<std::string>& ids = server.getVehicleStateChanges().find(state)->second;
+    outputStorage.writeUnsignedByte(libsumo::TYPE_STRINGLIST);
+    outputStorage.writeStringList(ids);
+}
+
+
+void
+TraCIServerAPI_Simulation::writeTransportableStateNumber(TraCIServer& server, tcpip::Storage& outputStorage, MSNet::TransportableState state) {
+    const std::vector<std::string>& ids = server.getTransportableStateChanges().find(state)->second;
+    outputStorage.writeUnsignedByte(libsumo::TYPE_INTEGER);
+    outputStorage.writeInt((int)ids.size());
+}
+
+
+void
+TraCIServerAPI_Simulation::writeTransportableStateIDs(TraCIServer& server, tcpip::Storage& outputStorage, MSNet::TransportableState state) {
+    const std::vector<std::string>& ids = server.getTransportableStateChanges().find(state)->second;
     outputStorage.writeUnsignedByte(libsumo::TYPE_STRINGLIST);
     outputStorage.writeStringList(ids);
 }

--- a/src/traci-server/TraCIServerAPI_Simulation.h
+++ b/src/traci-server/TraCIServerAPI_Simulation.h
@@ -76,6 +76,9 @@ private:
     static void writeVehicleStateNumber(TraCIServer& server, tcpip::Storage& outputStorage, MSNet::VehicleState state);
     static void writeVehicleStateIDs(TraCIServer& server, tcpip::Storage& outputStorage, MSNet::VehicleState state);
 
+    static void writeTransportableStateNumber(TraCIServer& server, tcpip::Storage& outputStorage, MSNet::TransportableState state);
+    static void writeTransportableStateIDs(TraCIServer& server, tcpip::Storage& outputStorage, MSNet::TransportableState state);
+
 
 private:
     /// @brief invalidated copy constructor

--- a/src/utils/traci/TraCIAPI.cpp
+++ b/src/utils/traci/TraCIAPI.cpp
@@ -1387,6 +1387,26 @@ TraCIAPI::SimulationScope::getEndingTeleportIDList() const {
     return getStringVector(libsumo::VAR_TELEPORT_ENDING_VEHICLES_IDS, "");
 }
 
+int
+TraCIAPI::SimulationScope::getDepartedPersonNumber() const {
+    return (int)getInt(libsumo::VAR_DEPARTED_PERSONS_NUMBER, "");
+}
+
+std::vector<std::string>
+TraCIAPI::SimulationScope::getDepartedPersonIDList() const {
+    return getStringVector(libsumo::VAR_DEPARTED_PERSONS_IDS, "");
+}
+
+int
+TraCIAPI::SimulationScope::getArrivedPersonNumber() const {
+    return (int)getInt(libsumo::VAR_ARRIVED_PERSONS_NUMBER, "");
+}
+
+std::vector<std::string>
+TraCIAPI::SimulationScope::getArrivedPersonIDList() const {
+    return getStringVector(libsumo::VAR_ARRIVED_PERSONS_IDS, "");
+}
+
 double
 TraCIAPI::SimulationScope::getDeltaT() const {
     return getDouble(libsumo::VAR_DELTA_T, "");

--- a/src/utils/traci/TraCIAPI.h
+++ b/src/utils/traci/TraCIAPI.h
@@ -426,6 +426,11 @@ public:
         libsumo::TraCIPositionVector getNetBoundary() const;
         int getMinExpectedNumber() const;
 
+        int getDepartedPersonNumber() const;
+        std::vector<std::string> getDepartedPersonIDList() const;
+        int getArrivedPersonNumber() const;
+        std::vector<std::string> getArrivedPersonIDList() const;
+
         int getBusStopWaiting(const std::string& stopID) const;
         std::vector<std::string> getBusStopWaitingIDList(const std::string& stopID) const;
 

--- a/tools/traci/_simulation.py
+++ b/tools/traci/_simulation.py
@@ -256,6 +256,36 @@ class SimulationDomain(Domain):
         """
         return self._getUniversal(tc.VAR_ARRIVED_VEHICLES_IDS)
 
+    def getDepartedPersonNumber(self):
+        """getDepartedPersonNumber() -> integer
+
+        Returns the number of persons which departed (were inserted into the road network) in this time step.
+        """
+        return self._getUniversal(tc.VAR_DEPARTED_PERSONS_NUMBER)
+
+    def getDepartedPersonIDList(self):
+        """getDepartedPersonIDList() -> list(string)
+
+        Returns a list of ids of persons which departed (were inserted into the road network) in this time step.
+        """
+        return self._getUniversal(tc.VAR_DEPARTED_PERSONS_IDS)
+
+    def getArrivedPersonNumber(self):
+        """getArrivedPersonNumber() -> integer
+
+        Returns the number of persons which arrived (have reached their destination and are removed from the road
+        network) in this time step.
+        """
+        return self._getUniversal(tc.VAR_ARRIVED_PERSONS_NUMBER)
+
+    def getArrivedPersonIDList(self):
+        """getArrivedPersonIDList() -> list(string)
+
+        Returns a list of ids of persons which arrived (have reached their destination and are removed from the road
+        network) in this time step.
+        """
+        return self._getUniversal(tc.VAR_ARRIVED_PERSONS_IDS)
+
     def getParkingStartingVehiclesNumber(self):
         """getParkingStartingVehiclesNumber() -> integer
 

--- a/tools/traci/constants.py
+++ b/tools/traci/constants.py
@@ -1123,6 +1123,18 @@ VAR_NET_BOUNDING_BOX = 0x7c
 #  minimum number of expected vehicles (get: simulation)
 VAR_MIN_EXPECTED_VEHICLES = 0x7d
 
+# number of departed persons (get: simulation)
+VAR_DEPARTED_PERSONS_NUMBER = 0x60
+
+# departed person ids (get: simulation)
+VAR_DEPARTED_PERSONS_IDS = 0x61
+
+# number of arrived persons (get: simulation)
+VAR_ARRIVED_PERSONS_NUMBER = 0x62
+
+# ids of arrived persons (get: simulation)
+VAR_ARRIVED_PERSONS_IDS = 0x63
+
 #  number of vehicles starting to park (get: simulation)
 VAR_STOP_STARTING_VEHICLES_NUMBER = 0x68
 


### PR DESCRIPTION
originiates from #3477. I created the TransportableState just like the current VehicleState with the same commands. Other transportable state changes or API-commands haven't been added, but should be possible to easily add them now.

I tested the commands with a python skript and it worked. I didnt check other ways though. Maybe you can add some kind of test or have the time to check it yourself.

Signed-off-by: Dominik Salles <dominik.salles@fkfs.de>