### PR TITLE
Added slope to ParkingArea spaces

### DIFF
--- a/data/xsd/additional_file.xsd
+++ b/data/xsd/additional_file.xsd
@@ -487,6 +487,7 @@
         <xsd:attribute name="width" type="positiveFloatType" use="optional"/>
         <xsd:attribute name="length" type="positiveFloatType" use="optional"/>
         <xsd:attribute name="angle" type="xsd:float" use="optional"/>
+        <xsd:attribute name="slope" type="xsd:float" use="optional"/>
     </xsd:complexType>
 
     <xsd:complexType name="calibratorType">

--- a/src/guisim/GUIParkingArea.cpp
+++ b/src/guisim/GUIParkingArea.cpp
@@ -181,8 +181,9 @@ GUIParkingArea::drawGL(const GUIVisualizationSettings& s) const {
 
 void
 GUIParkingArea::addLotEntry(double x, double y, double z,
-                            double width, double length, double angle) {
-    MSParkingArea::addLotEntry(x, y, z, width, length, angle);
+                            double width, double length,
+                            double angle, double slope) {
+    MSParkingArea::addLotEntry(x, y, z, width, length, angle, slope);
     Boundary b;
     b.add(Position(x, y));
     b.grow(MAX2(width, length) + 5);

--- a/src/guisim/GUIParkingArea.h
+++ b/src/guisim/GUIParkingArea.h
@@ -121,7 +121,8 @@ public:
 
     /// @brief extend boundary
     void addLotEntry(double x, double y, double z,
-                     double width, double length, double angle);
+                     double width, double length,
+                     double angle, double slope);
 
     /** @brief Draws the object
      * @param[in] s The settings for the current view (may influence drawing)

--- a/src/libsumo/Vehicle.cpp
+++ b/src/libsumo/Vehicle.cpp
@@ -158,7 +158,7 @@ Vehicle::getAngle(const std::string& vehID) {
 double
 Vehicle::getSlope(const std::string& vehID) {
     MSBaseVehicle* veh = Helper::getVehicle(vehID);
-    return veh->isOnRoad() ? veh->getSlope() : INVALID_DOUBLE_VALUE;
+    return (veh->isOnRoad() || veh->isParking()) ? veh->getSlope() : INVALID_DOUBLE_VALUE;
 }
 
 

--- a/src/microsim/MSParkingArea.h
+++ b/src/microsim/MSParkingArea.h
@@ -149,6 +149,9 @@ public:
     /// @brief Returns the angle of parked vehicle
     double getVehicleAngle(const SUMOVehicle& forVehicle) const;
 
+    /// @brief Returns the slope of parked vehicle
+    double getVehicleSlope(const SUMOVehicle& forVehicle) const;
+
     /** @brief Return the angle of myLastFreeLot - the next parking lot
      *         only expected to be called after we have established there is space in the parking area
      *
@@ -177,10 +180,12 @@ public:
      * @param[in] width Width of the lot rectangle
      * @param[in] length Length of the lot rectangle
      * @param[in] angle Angle of the lot rectangle
+     * @param[in] slope Slope of the lot rectangle
      * @return Whether the lot entry could be added
      */
     virtual void addLotEntry(double x, double y, double z,
-                             double width, double length, double angle);
+                             double width, double length,
+                             double angle, double slope);
 
     /// @brief Returns the lot rectangle width
     double getWidth() const;
@@ -209,7 +214,7 @@ protected:
         LotSpaceDefinition();
 
         /// @brief parameter constructor
-        LotSpaceDefinition(int index, SUMOVehicle* vehicle, double x, double y, double z, double rotation, double width, double length);
+        LotSpaceDefinition(int index, SUMOVehicle* vehicle, double x, double y, double z, double rotation, double slope, double width, double length);
 
         /// @brief the running index
         const int index;
@@ -222,6 +227,9 @@ protected:
 
         /// @brief The rotation
         const double rotation;
+
+        /// @brief The slope
+        const double slope;
 
         /// @brief The width
         const double width;

--- a/src/microsim/MSVehicle.cpp
+++ b/src/microsim/MSVehicle.cpp
@@ -1112,6 +1112,9 @@ MSVehicle::adaptLaneEntering2MoveReminder(const MSLane& enteredLane) {
 // ------------ Other getter methods
 double
 MSVehicle::getSlope() const {
+    if (!isOnRoad() && isParking() && getStops().begin()->parkingarea != nullptr) {
+        return getStops().begin()->parkingarea->getVehicleSlope(*this);
+    }
     if (myLane == nullptr) {
         return 0;
     }

--- a/src/netedit/elements/GNEAttributeCarrier.cpp
+++ b/src/netedit/elements/GNEAttributeCarrier.cpp
@@ -1651,6 +1651,12 @@ GNEAttributeCarrier::fillAdditionals() {
                                               "0.00");
         myTagProperties[currentTag].addAttribute(attrProperty);
 
+        attrProperty = GNEAttributeProperties(SUMO_ATTR_SLOPE,
+                                              GNEAttributeProperties::FLOAT | GNEAttributeProperties::ANGLE | GNEAttributeProperties::DEFAULTVALUESTATIC | GNEAttributeProperties::XMLOPTIONAL | GNEAttributeProperties::UPDATEGEOMETRY,
+                                              "The slope of the road-side parking spaces",
+                                              "0.00");
+        myTagProperties[currentTag].addAttribute(attrProperty);
+
     }
     currentTag = SUMO_TAG_E1DETECTOR;
     {

--- a/src/netedit/elements/additional/GNEAdditionalHandler.cpp
+++ b/src/netedit/elements/additional/GNEAdditionalHandler.cpp
@@ -355,8 +355,8 @@ GNEAdditionalHandler::buildParkingArea(GNENet* net, bool allowUndoRedo, const st
 
 
 GNEAdditional*
-GNEAdditionalHandler::buildParkingSpace(GNENet* net, bool allowUndoRedo, GNEAdditional* parkingAreaParent, Position pos, double width, double length, double angle, bool blockMovement) {
-    GNEAdditional* parkingSpace = new GNEParkingSpace(net, parkingAreaParent, pos, width, length, angle, blockMovement);
+GNEAdditionalHandler::buildParkingSpace(GNENet* net, bool allowUndoRedo, GNEAdditional* parkingAreaParent, Position pos, double width, double length, double angle, double slope, bool blockMovement) {
+    GNEAdditional* parkingSpace = new GNEParkingSpace(net, parkingAreaParent, pos, width, length, angle, slope, blockMovement);
     if (allowUndoRedo) {
         net->getViewNet()->getUndoList()->p_begin("add " + toString(SUMO_TAG_PARKING_SPACE));
         net->getViewNet()->getUndoList()->add(new GNEChange_Additional(parkingSpace, true), true);
@@ -2042,6 +2042,7 @@ GNEAdditionalHandler::parseAndBuildParkingSpace(GNENet* net, bool allowUndoRedo,
     double width = GNEAttributeCarrier::parseAttributeFromXML<double>(attrs, "", SUMO_TAG_PARKING_SPACE, SUMO_ATTR_WIDTH, abort);
     double length = GNEAttributeCarrier::parseAttributeFromXML<double>(attrs, "", SUMO_TAG_PARKING_SPACE, SUMO_ATTR_LENGTH, abort);
     double angle = GNEAttributeCarrier::parseAttributeFromXML<double>(attrs, "", SUMO_TAG_PARKING_SPACE, SUMO_ATTR_ANGLE, abort);
+    double slope = GNEAttributeCarrier::parseAttributeFromXML<double>(attrs, "", SUMO_TAG_PARKING_SPACE, SUMO_ATTR_SLOPE, abort);
     // parse Netedit attributes
     bool blockMovement = false;
     if (attrs.hasAttribute(GNE_ATTR_BLOCK_MOVEMENT)) {
@@ -2061,7 +2062,7 @@ GNEAdditionalHandler::parseAndBuildParkingSpace(GNENet* net, bool allowUndoRedo,
         // check that Parking Area Parent exists
         if (parkingAreaParent != nullptr) {
             // save ID of last created element
-            GNEAdditional* additionalCreated = buildParkingSpace(net, allowUndoRedo, parkingAreaParent, pos, width, length, angle, blockMovement);
+            GNEAdditional* additionalCreated = buildParkingSpace(net, allowUndoRedo, parkingAreaParent, pos, width, length, angle, slope, blockMovement);
             // check if insertion has to be commited
             if (insertedAdditionals) {
                 insertedAdditionals->commitAdditionalInsertion(additionalCreated);

--- a/src/netedit/elements/additional/GNEAdditionalHandler.h
+++ b/src/netedit/elements/additional/GNEAdditionalHandler.h
@@ -250,11 +250,12 @@ public:
      * @param[in] width ParkingArea's width
      * @param[in] length ParkingArea's length
      * @param[in] angle ParkingArea's angle
+     * @param[in] slope ParkingArea's slope (of this space)
      * @param[in] blockMovemet enable or disable block movement
      * @return true if was sucesfully created, false in other case
      * @exception InvalidArgument If the charging Station can not be added to the net (is duplicate)
      */
-    static GNEAdditional* buildParkingSpace(GNENet* net, bool allowUndoRedo, GNEAdditional* parkingAreaParent, Position pos, double width, double length, double angle, bool blockMovement);
+    static GNEAdditional* buildParkingSpace(GNENet* net, bool allowUndoRedo, GNEAdditional* parkingAreaParent, Position pos, double width, double length, double angle, double slope, bool blockMovement);
 
     /**@brief Builds a induction loop detector (E1)
      * @param[in] net net in which element will be inserted

--- a/src/netedit/elements/additional/GNEParkingSpace.cpp
+++ b/src/netedit/elements/additional/GNEParkingSpace.cpp
@@ -31,13 +31,14 @@
 // method definitions
 // ===========================================================================
 
-GNEParkingSpace::GNEParkingSpace(GNENet* net, GNEAdditional* parkingAreaParent, const Position& pos, double width, double length, double angle, bool blockMovement) :
+GNEParkingSpace::GNEParkingSpace(GNENet* net, GNEAdditional* parkingAreaParent, const Position& pos, double width, double length, double angle, double slope, bool blockMovement) :
     GNEAdditional(net, GLO_PARKING_SPACE, SUMO_TAG_PARKING_SPACE, "", blockMovement,
 {}, {}, {}, {parkingAreaParent}, {}, {}, {}, {}),
 myPosition(pos),
 myWidth(width),
 myLength(length),
-myAngle(angle) {
+myAngle(angle),
+mySlope(slope) {
     // update centering boundary without updating grid
     updateCenteringBoundary(false);
 }
@@ -171,6 +172,8 @@ GNEParkingSpace::getAttribute(SumoXMLAttr key) const {
             return toString(myLength);
         case SUMO_ATTR_ANGLE:
             return toString(myAngle);
+        case SUMO_ATTR_SLOPE:
+            return toString(mySlope);
         case GNE_ATTR_BLOCK_MOVEMENT:
             return toString(myBlockMovement);
         case GNE_ATTR_PARENT:
@@ -201,6 +204,7 @@ GNEParkingSpace::setAttribute(SumoXMLAttr key, const std::string& value, GNEUndo
         case SUMO_ATTR_WIDTH:
         case SUMO_ATTR_LENGTH:
         case SUMO_ATTR_ANGLE:
+        case SUMO_ATTR_SLOPE:
         case GNE_ATTR_BLOCK_MOVEMENT:
         case GNE_ATTR_PARENT:
         case GNE_ATTR_SELECTED:
@@ -223,6 +227,8 @@ GNEParkingSpace::isValid(SumoXMLAttr key, const std::string& value) {
         case SUMO_ATTR_LENGTH:
             return canParse<double>(value) && (parse<double>(value) > 0);
         case SUMO_ATTR_ANGLE:
+            return canParse<double>(value);
+        case SUMO_ATTR_SLOPE:
             return canParse<double>(value);
         case GNE_ATTR_BLOCK_MOVEMENT:
             return canParse<bool>(value);
@@ -279,6 +285,11 @@ GNEParkingSpace::setAttribute(SumoXMLAttr key, const std::string& value) {
             break;
         case SUMO_ATTR_ANGLE:
             myAngle = parse<double>(value);
+            // update boundary
+            updateCenteringBoundary(true);
+            break;
+        case SUMO_ATTR_SLOPE:
+            mySlope = parse<double>(value);
             // update boundary
             updateCenteringBoundary(true);
             break;

--- a/src/netedit/elements/additional/GNEParkingSpace.h
+++ b/src/netedit/elements/additional/GNEParkingSpace.h
@@ -44,9 +44,10 @@ public:
      * @param[in] width ParkingArea's width
      * @param[in] length ParkingArea's length
      * @param[in] angle ParkingArea's angle
+     * @param[in] slope ParkingArea's slope (of this space)
      * @param[in] block movement enable or disable additional movement
      */
-    GNEParkingSpace(GNENet* net, GNEAdditional* parkingAreaParent, const Position& pos, double width, double length, double angle, bool blockMovement);
+    GNEParkingSpace(GNENet* net, GNEAdditional* parkingAreaParent, const Position& pos, double width, double length, double angle, double slope, bool blockMovement);
 
     /// @brief Destructor
     ~GNEParkingSpace();
@@ -133,6 +134,9 @@ protected:
 
     /// @brief Angle of Parking Space
     double myAngle;
+
+    /// @brief Slope of Parking Space
+    double mySlope;
 
 private:
     /// @brief set attribute after validation

--- a/src/netload/NLTriggerBuilder.cpp
+++ b/src/netload/NLTriggerBuilder.cpp
@@ -579,8 +579,9 @@ NLTriggerBuilder::parseAndAddLotEntry(const SUMOSAXAttributes& attrs) {
     double width = attrs.getOpt<double>(SUMO_ATTR_WIDTH, "", ok, myParkingArea->getWidth());
     double length = attrs.getOpt<double>(SUMO_ATTR_LENGTH, "", ok, myParkingArea->getLength());
     double angle = attrs.getOpt<double>(SUMO_ATTR_ANGLE, "", ok, myParkingArea->getAngle());
+    double slope = attrs.getOpt<double>(SUMO_ATTR_SLOPE, "", ok, 0.);
     // add the lot entry
-    addLotEntry(x, y, z, width, length, angle);
+    addLotEntry(x, y, z, width, length, angle, slope);
 }
 
 
@@ -771,10 +772,11 @@ NLTriggerBuilder::beginParkingArea(MSNet& net, const std::string& id,
 
 void
 NLTriggerBuilder::addLotEntry(double x, double y, double z,
-                              double width, double length, double angle) {
+                              double width, double length,
+                              double angle, double slope) {
     if (myParkingArea != nullptr) {
         if (!myParkingArea->parkOnRoad()) {
-            myParkingArea->addLotEntry(x, y, z, width, length, angle);
+            myParkingArea->addLotEntry(x, y, z, width, length, angle, slope);
         } else {
             throw InvalidArgument("Cannot not add lot entry to on-road parking area.");
         }

--- a/src/netload/NLTriggerBuilder.h
+++ b/src/netload/NLTriggerBuilder.h
@@ -164,10 +164,12 @@ public:
      * @param[in] width Width of the lot rectangle
      * @param[in] length Length of the lot rectangle
      * @param[in] angle Angle of the lot rectangle
+     * @param[in] slope Slope of the lot rectangle
      * @exception InvalidArgument If the current parking area is 0
      */
     void addLotEntry(double x, double y, double z,
-                     double width, double length, double angle);
+                     double width, double length,
+                     double angle, double slope);
 
 
 

--- a/src/utils/geom/GeomHelper.cpp
+++ b/src/utils/geom/GeomHelper.cpp
@@ -325,4 +325,14 @@ GeomHelper::calculateLotSpaceAngle(const PositionVector& shape, const int index,
     return ((double)atan2((endOffset.x() - startOffset.x()), (startOffset.y() - endOffset.y())) * (double)180.0 / (double)M_PI) + angle;
 }
 
+
+double 
+GeomHelper::calculateLotSpaceSlope(const PositionVector& shape, const int index, const double spaceDim) {
+    // declare shape offsets
+    const Position startOffset = shape.positionAtOffset(spaceDim * (index));
+    const Position endOffset = shape.positionAtOffset(spaceDim * (index + 1));
+    // return slope
+    return (double)asin((startOffset.z() - endOffset.z()) / spaceDim) * (double)180.0 / (double)M_PI;
+}
+
 /****************************************************************************/

--- a/src/utils/geom/GeomHelper.h
+++ b/src/utils/geom/GeomHelper.h
@@ -161,4 +161,7 @@ public:
 
     /// @brief calculate lotSpace angle
     static double calculateLotSpaceAngle(const PositionVector& shape, const int index, const double spaceDim, const double angle);
+    
+    /// @brief calculate lotSpace slope
+    static double calculateLotSpaceSlope(const PositionVector& shape, const int index, const double spaceDim);
 };


### PR DESCRIPTION
Added slope to ParkingArea spaces to prevent transmission of INVALID_DOUBLE_VALUE for the slope of parked vehicles via TraCI. This way, also parked cars have a valid slope value.
Stating the slope of spaces is optional, so users who work with pure 2D scenarios are unaffected by the changes. In this case, the slope value is simply 0.
Also integrates with netedit.

Signed-off-by: Alexander Brummer <alexander.brummer@fau.de>