### PR TITLE
Double waitBetweenRetries between failures of traci connection.

### DIFF
--- a/tools/traci/main.py
+++ b/tools/traci/main.py
@@ -124,6 +124,7 @@ def connect(port=8813, numRetries=10, host="localhost", proc=None, waitBetweenRe
             if retry < numRetries + 1:
                 print(" Retrying in %s seconds" % waitBetweenRetries)
                 time.sleep(waitBetweenRetries)
+                waitBetweenRetries *= 2
     raise FatalTraCIError("Could not connect in %s tries" % (numRetries + 1))
 
 


### PR DESCRIPTION
When using traci in a slow cpu, traci keeps failing when starting. This is because after making a subprocess of sumo, the sumo process starts really slow while traci waits for only 10 seconds.

This PR will double waitBetweenRetries for slow cpus.