### PR TITLE
add getFilled to PolygonScope of C++ TraCI API

### DIFF
--- a/src/utils/traci/TraCIAPI.cpp
+++ b/src/utils/traci/TraCIAPI.cpp
@@ -1203,6 +1203,11 @@ TraCIAPI::PolygonScope::getLineWidth(const std::string& polygonID) const {
     return getDouble(libsumo::VAR_WIDTH, polygonID);
 }
 
+bool
+TraCIAPI::PolygonScope::getFilled(const std::string& polygonID) const {
+    return getInt(libsumo::VAR_FILL, polygonID) != 0;
+}
+
 std::string
 TraCIAPI::PolygonScope::getType(const std::string& polygonID) const {
     return getString(libsumo::VAR_TYPE, polygonID);

--- a/src/utils/traci/TraCIAPI.h
+++ b/src/utils/traci/TraCIAPI.h
@@ -356,6 +356,7 @@ public:
         virtual ~PolygonScope() {}
 
         double getLineWidth(const std::string& polygonID) const;
+        bool getFilled(const std::string& polygonID) const;
         std::string getType(const std::string& polygonID) const;
         libsumo::TraCIPositionVector getShape(const std::string& polygonID) const;
         libsumo::TraCIColor getColor(const std::string& polygonID) const;


### PR DESCRIPTION
This method corresponds to https://sumo.dlr.de/pydoc/traci._polygon.html#PolygonDomain-getFilled

Just as I have prepared this pull request, I have noticed that you are going to deprecate this old C++ TraCI API.
Anyhow, if you don't mind, I would be happy to see this addition upstream.