### PR TITLE
Add license information to libsumo/libtraci pom.xml

### DIFF
--- a/tools/build/pom.py
+++ b/tools/build/pom.py
@@ -88,6 +88,13 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <url>https://repo.eclipse.org/content/repositories/sumo-snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
+    
+    <licenses>
+        <license>
+            <name>Eclipse Public License - v 2.0</name>
+            <url>https://www.eclipse.org/legal/epl-2.0</url>
+        </license>
+    </licenses>
 
     <build>
         <plugins>


### PR DESCRIPTION
There are maven plugins (e.g. `org.codehaus.mojo:license-maven-plugin`) which check the license of artifacts. This requires the pom to include a `<licenses>` tag.