### PR TITLE
Added Person-TraCI commands to 'old' API, added net.netOffset and changed Person-SpeedFactor

### DIFF
--- a/src/libsumo/Person.cpp
+++ b/src/libsumo/Person.cpp
@@ -363,7 +363,7 @@ Person::getLength(const std::string& personID) {
 
 double
 Person::getSpeedFactor(const std::string& personID) {
-    return getPerson(personID)->getVehicleType().getSpeedFactor().getParameter()[0];
+    return getPerson(personID)->getSpeedFactor();
 }
 
 
@@ -1086,7 +1086,7 @@ Person::setLateralAlignment(const std::string& personID, const std::string& latA
 
 void
 Person::setSpeedFactor(const std::string& personID, double factor) {
-    getPerson(personID)->getSingularType().setSpeedFactor(factor);
+    getPerson(personID)->setSpeedFactor(factor);
 }
 
 
@@ -1154,6 +1154,8 @@ Person::handleVariable(const std::string& objID, const int variable, VariableWra
             return wrapper->wrapDouble(objID, variable, getWaitingTime(objID));
         case VAR_TYPE:
             return wrapper->wrapString(objID, variable, getTypeID(objID));
+        case VAR_SPEED_FACTOR:
+            return wrapper->wrapDouble(objID, variable, getSpeedFactor(objID));
         case VAR_NEXT_EDGE:
             return wrapper->wrapString(objID, variable, getNextEdge(objID));
         case VAR_STAGES_REMAINING:

--- a/src/libsumo/Simulation.cpp
+++ b/src/libsumo/Simulation.cpp
@@ -709,6 +709,14 @@ Simulation::getParameter(const std::string& objectID, const std::string& key) {
         } else {
             throw TraCIException("Invalid overhead wire parameter '" + attrName + "'");
         }
+    } else if (StringUtils::startsWith(key, "net.")) {
+        const std::string attrName = key.substr(4);
+        Position b = GeoConvHelper::getFinal().getOffsetBase();
+        if (attrName == toString(SUMO_ATTR_NET_OFFSET)) {
+            return toString(GeoConvHelper::getFinal().getOffsetBase());
+        } else {
+            throw TraCIException("Invalid net parameter '" + attrName + "'");
+        }
     } else if (StringUtils::startsWith(key, "parkingArea.")) {
         const std::string attrName = key.substr(12);
         MSParkingArea* pa = static_cast<MSParkingArea*>(MSNet::getInstance()->getStoppingPlace(objectID, SUMO_TAG_PARKING_AREA));

--- a/src/microsim/transportables/MSPerson.h
+++ b/src/microsim/transportables/MSPerson.h
@@ -271,6 +271,10 @@ public:
         return myChosenSpeedFactor;
     }
 
+    inline void setSpeedFactor(const double factor) {
+        myChosenSpeedFactor = factor;
+    }
+
     /// @brief set new walk and replace the stages with relative indices in the interval [firstIndex, nextIndex[
     void reroute(ConstMSEdgeVector& newEdges, double departPos, int firstIndex, int nextIndex);
 
@@ -334,7 +338,7 @@ private:
     /// @brief An instance of a speed/position influencing instance; built in "getInfluencer"
     Influencer* myInfluencer;
 
-    const double myChosenSpeedFactor;
+    double myChosenSpeedFactor;
 
 private:
     /// @brief Invalidated copy constructor.

--- a/src/traci-server/TraCIServerAPI_Person.cpp
+++ b/src/traci-server/TraCIServerAPI_Person.cpp
@@ -136,6 +136,7 @@ TraCIServerAPI_Person::processSet(TraCIServer& server, tcpip::Storage& inputStor
             && variable != libsumo::MOVE_TO_XY
             && variable != libsumo::VAR_SPEED
             && variable != libsumo::VAR_TYPE
+            && variable != libsumo::VAR_SPEED_FACTOR
             && variable != libsumo::VAR_LENGTH
             && variable != libsumo::VAR_WIDTH
             && variable != libsumo::VAR_HEIGHT
@@ -177,6 +178,14 @@ TraCIServerAPI_Person::processSet(TraCIServer& server, tcpip::Storage& inputStor
                 libsumo::Person::setType(id, vTypeID);
                 break;
             }
+            case libsumo::VAR_SPEED_FACTOR: {
+                double speedfactor = 0;
+                if (!server.readTypeCheckingDouble(inputStorage, speedfactor)) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_PERSON_VARIABLE, "Setting SpeedFactor requires a double.", outputStorage);
+                }
+                libsumo::Person::setSpeedFactor(id, speedfactor);
+            }
+            break;
             case libsumo::VAR_COLOR: {
                 libsumo::TraCIColor col;
                 if (!server.readTypeCheckingColor(inputStorage, col)) {

--- a/src/utils/traci/TraCIAPI.cpp
+++ b/src/utils/traci/TraCIAPI.cpp
@@ -3206,6 +3206,11 @@ TraCIAPI::PersonScope::getTypeID(const std::string& personID) const {
 }
 
 double
+TraCIAPI::PersonScope::getSpeedFactor(const std::string& personID) const {
+    return getDouble(libsumo::VAR_SPEED_FACTOR, personID);
+}
+
+double
 TraCIAPI::PersonScope::getWaitingTime(const std::string& personID) const {
     return getDouble(libsumo::VAR_WAITING_TIME, personID);
 }
@@ -3379,6 +3384,37 @@ TraCIAPI::PersonScope::removeStage(const std::string& personID, int nextStageInd
     myParent.processSet(libsumo::CMD_SET_PERSON_VARIABLE);
 }
 
+void
+TraCIAPI::PersonScope::moveTo(const std::string& personID, const std::string& edgeID, double position) const {
+    tcpip::Storage content;
+    content.writeUnsignedByte(libsumo::TYPE_COMPOUND);
+    content.writeInt(2);
+    content.writeUnsignedByte(libsumo::TYPE_STRING);
+    content.writeString(edgeID);
+    content.writeUnsignedByte(libsumo::TYPE_DOUBLE);
+    content.writeDouble(position);
+    myParent.createCommand(libsumo::CMD_SET_PERSON_VARIABLE, libsumo::VAR_MOVE_TO, personID, &content);
+    myParent.processSet(libsumo::CMD_SET_PERSON_VARIABLE);
+}
+
+void
+TraCIAPI::PersonScope::moveToXY(const std::string& personID, const std::string& edgeID, const double x, const double y, double angle, const int keepRoute) const {
+    tcpip::Storage content;
+    content.writeUnsignedByte(libsumo::TYPE_COMPOUND);
+    content.writeInt(5);
+    content.writeUnsignedByte(libsumo::TYPE_STRING);
+    content.writeString(edgeID);
+    content.writeUnsignedByte(libsumo::TYPE_DOUBLE);
+    content.writeDouble(x);
+    content.writeUnsignedByte(libsumo::TYPE_DOUBLE);
+    content.writeDouble(y);
+    content.writeUnsignedByte(libsumo::TYPE_DOUBLE);
+    content.writeDouble(angle);
+    content.writeUnsignedByte(libsumo::TYPE_BYTE);
+    content.writeByte(keepRoute);
+    myParent.createCommand(libsumo::CMD_SET_PERSON_VARIABLE, libsumo::MOVE_TO_XY, personID, &content);
+    myParent.processSet(libsumo::CMD_SET_PERSON_VARIABLE);
+}
 
 void
 TraCIAPI::PersonScope::setSpeed(const std::string& personID, double speed) const {
@@ -3396,6 +3432,15 @@ TraCIAPI::PersonScope::setType(const std::string& personID, const std::string& t
     content.writeUnsignedByte(libsumo::TYPE_STRING);
     content.writeString(typeID);
     myParent.createCommand(libsumo::CMD_SET_PERSON_VARIABLE, libsumo::VAR_TYPE, personID, &content);
+    myParent.processSet(libsumo::CMD_SET_PERSON_VARIABLE);
+}
+
+void
+TraCIAPI::PersonScope::setSpeedFactor(const std::string& personID, double factor) const {
+    tcpip::Storage content;
+    content.writeUnsignedByte(libsumo::TYPE_DOUBLE);
+    content.writeDouble(factor);
+    myParent.createCommand(libsumo::CMD_SET_PERSON_VARIABLE, libsumo::VAR_SPEED_FACTOR, personID, &content);
     myParent.processSet(libsumo::CMD_SET_PERSON_VARIABLE);
 }
 

--- a/src/utils/traci/TraCIAPI.h
+++ b/src/utils/traci/TraCIAPI.h
@@ -770,6 +770,7 @@ public:
         std::string getRoadID(const std::string& personID) const;
         std::string getLaneID(const std::string& personID) const;
         std::string getTypeID(const std::string& personID) const;
+        double getSpeedFactor(const std::string& personID) const;
         double getWaitingTime(const std::string& personID) const;
         std::string getNextEdge(const std::string& personID) const;
         std::string getVehicle(const std::string& personID) const;
@@ -795,8 +796,11 @@ public:
         void appendDrivingStage(const std::string& personID, const std::string& toEdge, const std::string& lines, const std::string& stopID = "");
         void removeStage(const std::string& personID, int nextStageIndex) const;
         void rerouteTraveltime(const std::string& personID) const;
+        void moveTo(const std::string& personID, const std::string& edgeID, double position) const;
+        void moveToXY(const std::string& personID, const std::string& edgeID, const double x, const double y, double angle, const int keepRoute) const;
         void setSpeed(const std::string& personID, double speed) const;
         void setType(const std::string& personID, const std::string& typeID) const;
+        void setSpeedFactor(const std::string& personID, double factor) const;
         void setLength(const std::string& personID, double length) const;
         void setWidth(const std::string& personID, double width) const;
         void setHeight(const std::string& personID, double height) const;


### PR DESCRIPTION

I changed/added a few TraCI-commands and therefore created a pull request:
- Added a new command to `getParameter` to get the netOffset via TraCI-C++-Command
- Added the commands `getSpeedFactor`, `moveTo`, `moveToXY` and `setSpeedFactor` to the "old, deprecated" TraCI-API, as I will still need a bit of time to transfer to libtraci (I already have a dublicate libsumo-structure that works fine).
- Changed the `getSpeedFactor` and `setSpeedFactor` commands, because they didn't get or set the ChosenSpeedFactor, but rather get the value from the VType. Also setting the value didn't really transfer to the ChosenSpeedFactor correctly.

If everything looks good --> thanks for adding! If not, feel free to change it.

Signed-off-by: Dominik Salles <dominik.salles@fkfs.de>