### PR TITLE
Fix capitalization of W99 car following parameters

### DIFF
--- a/docs/web/docs/Definition_of_Vehicles,_Vehicle_Types,_and_Routes.md
+++ b/docs/web/docs/Definition_of_Vehicles,_Vehicle_Types,_and_Routes.md
@@ -755,16 +755,16 @@ lists which parameter are used by which model(s). [Details on car-following mode
 | gapControlGainGapDot         | 0.0125                                                  |          | The control gain determining the rate of the positioning deviation derivative (Gap control mode)          | CACC      |
 | collisionAvoidanceGainGap    | 0.45                                                    |          | The control gain determining the rate of positioning deviation (Collision avoidance mode)                 | CACC      |
 | collisionAvoidanceGainGapDot | 0.05                                                    |          | The control gain determining the rate of the positioning deviation derivative (Collision avoidance mode)  | CACC      |
-| CC1                          |                                                       |          | Spacing Time - s                                                                                          | W99       |
-| CC2                          |                                                       |          | Following Variation - m                                                                                   | W99       |
-| CC3                          |                                                       |          | Threshold for Entering "Following" - s                                                                    | W99       |
-| CC4                          |                                                       |          | Negative "Following" Threshold - m/s                                                                      | W99       |
-| CC5                          |                                                       |          | Positive "Following" Threshold - m/s                                                                      | W99       |
-| CC6                          |                                                       |          | Speed Dependency of Oscillation - 10^-4 rad/s                                                             | W99       |
-| CC7                          |                                                       |          | Oscillation Acceleration - m/s^2                                                                          | W99       |
-| CC8                          |                                                       |          | Standstill Acceleration - m/s^2                                                                           | W99       |
-| CC9                          |                                                       |          | Acceleration at 80km/h - m/s^2                                                                            | W99       |
-| trainType                    |                                                       |          | [string id for pre-defined train type](Simulation/Railways.md#modelling_trains)                           | Rail      |
+| cc1                          |                                                         |          | Spacing Time - s                                                                                          | W99       |
+| cc2                          |                                                         |          | Following Variation - m                                                                                   | W99       |
+| cc3                          |                                                         |          | Threshold for Entering "Following" - s                                                                    | W99       |
+| cc4                          |                                                         |          | Negative "Following" Threshold - m/s                                                                      | W99       |
+| cc5                          |                                                         |          | Positive "Following" Threshold - m/s                                                                      | W99       |
+| cc6                          |                                                         |          | Speed Dependency of Oscillation - 10^-4 rad/s                                                             | W99       |
+| cc7                          |                                                         |          | Oscillation Acceleration - m/s^2                                                                          | W99       |
+| cc8                          |                                                         |          | Standstill Acceleration - m/s^2                                                                           | W99       |
+| cc9                          |                                                         |          | Acceleration at 80km/h - m/s^2                                                                            | W99       |
+| trainType                    |                                                         |          | [string id for pre-defined train type](Simulation/Railways.md#modelling_trains)                           | Rail      |
 
 To select a car following model the following syntax should be used:
 


### PR DESCRIPTION
SUMO complains if the capitalization from the documentation is used and not the one from [SUMOXMLDefinitions.cpp#L722-L730](https://github.com/eclipse/sumo/blob/master/src/utils/xml/SUMOXMLDefinitions.cpp#L722-L730).