### PR TITLE
traci: don't try to read parameters for subscriptions that don't have them

### DIFF
--- a/src/traci-server/TraCIServer.cpp
+++ b/src/traci-server/TraCIServer.cpp
@@ -292,10 +292,10 @@ TraCIServer::TraCIServer(const SUMOTime begin, const int port, const int numClie
     myExecutors[libsumo::CMD_GET_OVERHEADWIRE_VARIABLE] = &TraCIServerAPI_OverheadWire::processGet;
     myExecutors[libsumo::CMD_SET_OVERHEADWIRE_VARIABLE] = &TraCIServerAPI_OverheadWire::processSet;
 
-    myParameterized.insert(libsumo::VAR_LEADER);
-    myParameterized.insert(libsumo::VAR_FOLLOWER);
-    myParameterized.insert(libsumo::VAR_PARAMETER);
-    myParameterized.insert(libsumo::VAR_PARAMETER_WITH_KEY);
+    myParameterized.insert(std::make_pair(libsumo::CMD_SUBSCRIBE_VEHICLE_VARIABLE, libsumo::VAR_LEADER));
+    myParameterized.insert(std::make_pair(libsumo::CMD_SUBSCRIBE_VEHICLE_VARIABLE, libsumo::VAR_FOLLOWER));
+    myParameterized.insert(std::make_pair(0, libsumo::VAR_PARAMETER));
+    myParameterized.insert(std::make_pair(0, libsumo::VAR_PARAMETER_WITH_KEY));
 
     myDoCloseConnection = false;
 
@@ -1271,7 +1271,7 @@ TraCIServer::addObjectVariableSubscription(const int commandId, const bool hasCo
         const int varID = myInputStorage.readUnsignedByte();
         variables.push_back(varID);
         parameters.push_back(std::make_shared<tcpip::Storage>());
-        if (myParameterized.count(varID) > 0) {
+        if ((myParameterized.count(std::make_pair(0, varID)) > 0) || (myParameterized.count(std::make_pair(commandId, varID)) > 0)) {
             const int parType = myInputStorage.readUnsignedByte();
             parameters.back()->writeUnsignedByte(parType);
             if (parType == libsumo::TYPE_DOUBLE) {

--- a/src/traci-server/TraCIServer.h
+++ b/src/traci-server/TraCIServer.h
@@ -387,7 +387,7 @@ private:
     std::map<int, CmdExecutor> myExecutors;
 
     /// @brief Set of variables which have parameters
-    std::set<int> myParameterized;
+    std::set<std::pair<int, int>> myParameterized;
 
     std::vector<std::string> myLoadArgs;
 


### PR DESCRIPTION
I just tried out SUMO 1.9.1 with Veins 5.1 and encountered a breaking bug: 74d2f044c899fc185ff47689bc0780676cb8ab37 introduced a more flexible way of reading parameters for object subscriptions, but both `VAR_FOLLOWER` (of `CMD_SUBSCRIBE_VEHICLE_VARIABLE`) and `VAR_TELEPORT_ENDING_VEHICLES_IDS` (of `CMD_SUBSCRIBE_SIM_VARIABLE`) have the same value (`0x78`). This leads `TraCIServer::addObjectVariableSubscription`  to expect parameters for `VAR_TELEPORT_ENDING_VEHICLES_IDS`, instantly breaking the connection.

I am attaching a crude patch that works around this by tracking "this requires a parameter" not just for variables, but for a combination of command-and-variable (using the value `0` as a wildcard)