### PR TITLE
Added lateralSpeed to Persons walking-angle

### DIFF
--- a/src/microsim/transportables/MSPModel_Striping.h
+++ b/src/microsim/transportables/MSPModel_Striping.h
@@ -292,6 +292,8 @@ protected:
         double myRelY;
         /// @brief the walking direction on the current lane (1 forward, -1 backward)
         int myDir;
+        /// @brief the current lateral walking speed
+        double mySpeedLat;
         /// @brief the current walking speed
         double mySpeed;
         /// @brief whether the pedestrian is waiting to start its walk


### PR DESCRIPTION
lateralSpeed of Pedestrians is now saved in mySpeedLat and used to calculate the correct angle depending on the walking direction and speed when "striping" on WalkingAreas and Lanes.

Signed-off-by: Dominik Salles <dominik.salles@fkfs.de>