### PR TITLE
Adding a new MSCFModel-function to make the upper speed bound CF-configurable

### DIFF
--- a/src/microsim/MSVehicle.cpp
+++ b/src/microsim/MSVehicle.cpp
@@ -1999,7 +1999,7 @@ MSVehicle::planMoveInternal(const SUMOTime t, MSLeaderInfo ahead, DriveItemVecto
         laneMaxV = std::numeric_limits<double>::max();
     }
     // v is the initial maximum velocity of this vehicle in this step
-    double v = MIN2(maxV, laneMaxV);
+    double v = cfModel.maximumLaneSpeedCF(maxV, laneMaxV);
     // if we are modelling parking then we dawdle until the manoeuvre is complete - by setting a very low max speed
     //   in practice this only applies to exit manoeuvre because entry manoeuvre just delays setting stop.reached - when the vehicle is virtually stopped
     if (MSGlobals::gModelParkingManoeuver && !manoeuvreIsComplete()) {

--- a/src/microsim/cfmodels/MSCFModel.h
+++ b/src/microsim/cfmodels/MSCFModel.h
@@ -194,6 +194,15 @@ public:
     virtual double interactionGap(const MSVehicle* const veh, double vL) const;
 
 
+    /** @brief Returns the maximum velocity the CF-model wants to achieve in the next step
+     * @param[in] maxSpeed The maximum achievable speed in the next step
+     * @param[in] maxSpeedLane The maximum speed the vehicle wants to drive on this lane (Speedlimit*SpeedFactor)
+     */
+    virtual double maximumLaneSpeedCF(double maxSpeed, double maxSpeedLane) const {
+        return MIN2(maxSpeed, maxSpeedLane);
+    }
+
+
     /** @brief Returns the model's ID; the XML-Tag number is used
      * @return The model's ID
      */


### PR DESCRIPTION
as discussed yesterday. I tested it again and this is the only change needed to let the Extended IDM drive/dawdle higher than laneMaxV, because the maximumLaneSpeedCF-function is configurable for each model then.

Feel free to change the name.

Solves issue #7644 for me.

Signed-off-by: Dominik Salles <dominik.salles@fkfs.de>