### PR TITLE
Fix libsumo headers

### DIFF
--- a/src/libsumo/TraCIConstants.h
+++ b/src/libsumo/TraCIConstants.h
@@ -28,7 +28,6 @@
 // holds codes used for TraCI
 /****************************************************************************/
 #pragma once
-#include <config.h>
 
 #if __cplusplus >= 201103L
 #define TRACI_CONST constexpr

--- a/src/libsumo/Vehicle.h
+++ b/src/libsumo/Vehicle.h
@@ -30,6 +30,7 @@
 // class declarations
 // ===========================================================================
 #ifndef LIBTRACI
+class PositionVector;
 class SUMOVehicle;
 #endif
 


### PR DESCRIPTION
After installing a SUMO CMake build with `make install`, I cannot use the installed libsumo headers in a third-party project without these modifications.