### PR TITLE
Changes to EIDM for second-step simulation and stopping

### DIFF
--- a/data/xsd/routeTypes.xsd
+++ b/data/xsd/routeTypes.xsd
@@ -215,15 +215,22 @@
         <xsd:attribute name="collisionAvoidanceGainGapDot" type="xsd:float"/>
         <xsd:attribute name="tPersDrive" type="positiveFloatType"/>
         <xsd:attribute name="tpreview" type="positiveFloatType"/>
-        <xsd:attribute name="treaction" type="positiveFloatType"/>
+        <xsd:attribute name="treaction" type="nonNegativeFloatType"/>
         <xsd:attribute name="tPersEstimate" type="positiveFloatType"/>
-        <xsd:attribute name="ccoolness" type="positiveFloatType"/>
-        <xsd:attribute name="sigmaleader" type="positiveFloatType"/>
-        <xsd:attribute name="sigmagap" type="positiveFloatType"/>
-        <xsd:attribute name="sigmaerror" type="positiveFloatType"/>
+        <xsd:attribute name="ccoolness">
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:float">
+                    <xsd:maxInclusive value="1"/>
+                    <xsd:minInclusive value="0"/>
+                </xsd:restriction>
+            </xsd:simpleType>
+        </xsd:attribute>
+        <xsd:attribute name="sigmaleader" type="nonNegativeFloatType"/>
+        <xsd:attribute name="sigmagap" type="nonNegativeFloatType"/>
+        <xsd:attribute name="sigmaerror" type="nonNegativeFloatType"/>
         <xsd:attribute name="jerkmax" type="positiveFloatType"/>
-        <xsd:attribute name="epsilonacc" type="positiveFloatType"/>
-        <xsd:attribute name="taccmax" type="positiveFloatType"/>
+        <xsd:attribute name="epsilonacc" type="nonNegativeFloatType"/>
+        <xsd:attribute name="taccmax" type="nonNegativeFloatType"/>
         <xsd:attribute name="Mflatness" type="positiveFloatType"/>
         <xsd:attribute name="Mbegin" type="positiveFloatType"/>
         <xsd:attribute name="vehdynamics" type="boolType"/>
@@ -243,7 +250,7 @@
         </xsd:attribute>
         <xsd:attribute name="tau" type="nonNegativeFloatType"/>
         <xsd:attribute name="delta" type="xsd:float"/>
-        <xsd:attribute name="stepping" type="positiveIntType"/>
+        <xsd:attribute name="stepping" type="positiveFloatType"/>
     </xsd:complexType>
 
     <xsd:complexType name="cfIDMMType">
@@ -260,13 +267,20 @@
         <xsd:attribute name="tau" type="nonNegativeFloatType"/>
         <xsd:attribute name="adaptTime" type="xsd:float"/>
         <xsd:attribute name="adaptFactor" type="xsd:float"/>
-        <xsd:attribute name="stepping" type="positiveIntType"/>
+        <xsd:attribute name="stepping" type="positiveFloatType"/>
     </xsd:complexType>
 
     <xsd:complexType name="cfEIDMType">
         <xsd:attribute name="accel" type="positiveFloatType"/>
         <xsd:attribute name="decel" type="positiveFloatType"/>
-        <xsd:attribute name="sigma">
+        <xsd:attribute name="stepping" type="positiveFloatType"/>
+        <xsd:attribute name="delta" type="xsd:float"/>
+        <xsd:attribute name="tau" type="positiveFloatType"/>
+        <xsd:attribute name="tPersDrive" type="positiveFloatType"/>
+        <xsd:attribute name="tpreview" type="positiveFloatType"/>
+        <xsd:attribute name="treaction" type="nonNegativeFloatType"/>
+        <xsd:attribute name="tPersEstimate" type="positiveFloatType"/>
+        <xsd:attribute name="ccoolness">
             <xsd:simpleType>
                 <xsd:restriction base="xsd:float">
                     <xsd:maxInclusive value="1"/>
@@ -274,19 +288,12 @@
                 </xsd:restriction>
             </xsd:simpleType>
         </xsd:attribute>
-        <xsd:attribute name="delta" type="xsd:float"/>
-        <xsd:attribute name="tau" type="positiveFloatType"/>
-        <xsd:attribute name="tPersDrive" type="positiveFloatType"/>
-        <xsd:attribute name="tpreview" type="positiveFloatType"/>
-        <xsd:attribute name="treaction" type="positiveFloatType"/>
-        <xsd:attribute name="tPersEstimate" type="positiveFloatType"/>
-        <xsd:attribute name="ccoolness" type="positiveFloatType"/>
-        <xsd:attribute name="sigmaleader" type="positiveFloatType"/>
-        <xsd:attribute name="sigmagap" type="positiveFloatType"/>
-        <xsd:attribute name="sigmaerror" type="positiveFloatType"/>
+        <xsd:attribute name="sigmaleader" type="nonNegativeFloatType"/>
+        <xsd:attribute name="sigmagap" type="nonNegativeFloatType"/>
+        <xsd:attribute name="sigmaerror" type="nonNegativeFloatType"/>
         <xsd:attribute name="jerkmax" type="positiveFloatType"/>
-        <xsd:attribute name="epsilonacc" type="positiveFloatType"/>
-        <xsd:attribute name="taccmax" type="positiveFloatType"/>
+        <xsd:attribute name="epsilonacc" type="nonNegativeFloatType"/>
+        <xsd:attribute name="taccmax" type="nonNegativeFloatType"/>
         <xsd:attribute name="Mflatness" type="positiveFloatType"/>
         <xsd:attribute name="Mbegin" type="positiveFloatType"/>
         <xsd:attribute name="vehdynamics" type="boolType"/>

--- a/src/microsim/cfmodels/MSCFModel_EIDM.h
+++ b/src/microsim/cfmodels/MSCFModel_EIDM.h
@@ -266,7 +266,7 @@ private:
 private:
     // @brief contains the main CF-model calculations
     double _v(const MSVehicle* const veh, const double gap2pred, const double mySpeed,
-              const double predSpeed, const double desSpeed, const bool respectMinGap, int update) const;
+              const double predSpeed, const double desSpeed, const bool respectMinGap, const int update) const;
 
     // @brief calculates the internal desired speed for the vehicle depending on myTpreview and upcoming turns, intersections and speed limit changes
     void internalspeedlimit(MSVehicle* const veh, const double oldV) const;
@@ -280,7 +280,10 @@ private:
 
     // @brief A computational shortcut
     const double myTwoSqrtAccelDecel;
-    
+
+    // @brief The number of iterations in speed calculations
+    const int myIterations;
+
     // @brief Correlation time of the Wiener Process for the driving error
     const double myTPersDrive;
 

--- a/src/netedit/dialogs/GNEVehicleTypeDialog.cpp
+++ b/src/netedit/dialogs/GNEVehicleTypeDialog.cpp
@@ -1460,6 +1460,7 @@ GNEVehicleTypeDialog::CarFollowingModelParameters::refreshCFMFields() {
                 myDecelRow->show();
                 myEmergencyDecelRow->show();
                 myDeltaRow->show();
+                mySteppingRow->show();
                 myMinGapFactorRow->show();
                 myTpreviewRow->show();
                 myTreactionRow->show();

--- a/src/utils/vehicle/SUMOVehicleParserHelper.cpp
+++ b/src/utils/vehicle/SUMOVehicleParserHelper.cpp
@@ -978,21 +978,21 @@ SUMOVehicleParserHelper::parseVTypeEmbedded(SUMOVTypeParameter& into, const Sumo
                 }
             } else if (it == SUMO_ATTR_CF_IDM_STEPPING) {
                 // declare a int in wich save CFM int attribute
-                int CFMIntAttribute = -1;
+                double CFMDoubleAttribute = -1;
                 try {
                     // obtain CFM attribute in int format
-                    CFMIntAttribute = StringUtils::toInt(parsedCFMAttribute);
+                    CFMDoubleAttribute = StringUtils::toDouble(parsedCFMAttribute);
                 } catch (...) {
                     ok = false;
                     if (hardFail) {
-                        throw ProcessError("Invalid Car-Following-Model Attribute " + toString(it) + ". Cannot be parsed to int");
+                        throw ProcessError("Invalid Car-Following-Model Attribute " + toString(it) + ". Cannot be parsed to float");
                     } else {
-                        WRITE_ERROR("Invalid Car-Following-Model Attribute " + toString(it) + ". Cannot be parsed to int");
+                        WRITE_ERROR("Invalid Car-Following-Model Attribute " + toString(it) + ". Cannot be parsed to float");
                     }
                 }
                 // now continue checking other properties
                 if (ok) {
-                    if (CFMIntAttribute <= 0) {
+                    if (CFMDoubleAttribute <= 0) {
                         ok = false;
                         if (hardFail) {
                             throw ProcessError("Invalid Car-Following-Model Attribute " + toString(it) + ". Must be greater than 0");
@@ -1164,6 +1164,7 @@ SUMOVehicleParserHelper::getAllowedCFModelAttrs() {
         eidmParams.insert(SUMO_ATTR_COLLISION_MINGAP_FACTOR);
         eidmParams.insert(SUMO_ATTR_TAU);
         eidmParams.insert(SUMO_ATTR_CF_IDM_DELTA);
+        eidmParams.insert(SUMO_ATTR_CF_IDM_STEPPING);
         eidmParams.insert(SUMO_ATTR_CF_EIDM_T_LOOK_AHEAD);
         eidmParams.insert(SUMO_ATTR_CF_EIDM_T_PERSISTENCE_DRIVE);
         eidmParams.insert(SUMO_ATTR_CF_EIDM_T_REACTION);


### PR DESCRIPTION
- Changed the tolerance when stopping, should have a similar stopping tolerance as the IDM now
- Added myIterations back to the Code, works the same way as with the IDM now
- Deleted the vehicle type cloning for minGap

I tested the circles-scenario again and also found differences for the Linux-Output and the Windows-Output. In my StuttgartDegerloch-Scenario I could not reproduce the issue, may have something to do with teleporting.

- Teleporting and warnings still happen for the circle-scenario, due to the Improved and Enhanced IDM. I changed the Code to act similar to the original IDM (coolness=0 and errors=0) and did not have any collisions or warnings.
- "Stepping" gave me errors in SUMO when using it as a float-value, for the input parser it is expected to be an integer. I changed the Code here, please check if that is/was ok.

Signed-off-by: Dominik Salles <dominik.salles@fkfs.de>