### PR TITLE
Added parameter to setPreviousSpeed

### DIFF
--- a/src/libsumo/Vehicle.cpp
+++ b/src/libsumo/Vehicle.cpp
@@ -1409,19 +1409,15 @@ Vehicle::setSpeed(const std::string& vehID, double speed) {
 }
 
 void
-Vehicle::setPreviousSpeed(const std::string& vehID, double prevspeed, int timefactor) {
+Vehicle::setPreviousSpeed(const std::string& vehID, double prevSpeed, double prevAcceleration) {
     MSBaseVehicle* vehicle = Helper::getVehicle(vehID);
     MSVehicle* veh = dynamic_cast<MSVehicle*>(vehicle);
     if (veh == nullptr) {
         WRITE_WARNING("setPreviousSpeed not yet implemented for meso");
         return;
     }
-	if (timefactor < 1) {
-		WRITE_WARNING("Timefactor must be a positive integer. Was set to 1");
-		timefactor = 1;
-	}
 
-    veh->setPreviousSpeed(prevspeed, timefactor);
+    veh->setPreviousSpeed(prevSpeed, prevAcceleration);
 }
 
 void

--- a/src/libsumo/Vehicle.cpp
+++ b/src/libsumo/Vehicle.cpp
@@ -1409,15 +1409,19 @@ Vehicle::setSpeed(const std::string& vehID, double speed) {
 }
 
 void
-Vehicle::setPreviousSpeed(const std::string& vehID, double prevspeed) {
+Vehicle::setPreviousSpeed(const std::string& vehID, double prevspeed, int timefactor) {
     MSBaseVehicle* vehicle = Helper::getVehicle(vehID);
     MSVehicle* veh = dynamic_cast<MSVehicle*>(vehicle);
     if (veh == nullptr) {
         WRITE_WARNING("setPreviousSpeed not yet implemented for meso");
         return;
     }
+	if (timefactor < 1) {
+		WRITE_WARNING("Timefactor must be a positive integer. Was set to 1");
+		timefactor = 1;
+	}
 
-    veh->setPreviousSpeed(prevspeed);
+    veh->setPreviousSpeed(prevspeed, timefactor);
 }
 
 void

--- a/src/libsumo/Vehicle.h
+++ b/src/libsumo/Vehicle.h
@@ -165,7 +165,7 @@ public:
     static void deactivateGapControl(const std::string& vehID);
     static void requestToC(const std::string& vehID, double leadTime);
     static void setSpeed(const std::string& vehID, double speed);
-    static void setPreviousSpeed(const std::string& vehID, double prevspeed);
+    static void setPreviousSpeed(const std::string& vehID, double prevspeed, int timefactor);
     static void setSpeedMode(const std::string& vehID, int speedMode);
     static void setLaneChangeMode(const std::string& vehID, int laneChangeMode);
     static void setRoutingMode(const std::string& vehID, int routingMode);

--- a/src/libsumo/Vehicle.h
+++ b/src/libsumo/Vehicle.h
@@ -165,7 +165,7 @@ public:
     static void deactivateGapControl(const std::string& vehID);
     static void requestToC(const std::string& vehID, double leadTime);
     static void setSpeed(const std::string& vehID, double speed);
-    static void setPreviousSpeed(const std::string& vehID, double prevspeed, int timefactor);
+    static void setPreviousSpeed(const std::string& vehID, double prevSpeed, double prevAcceleration = std::numeric_limits<int>::min());
     static void setSpeedMode(const std::string& vehID, int speedMode);
     static void setLaneChangeMode(const std::string& vehID, int laneChangeMode);
     static void setRoutingMode(const std::string& vehID, int routingMode);

--- a/src/libtraci/Vehicle.cpp
+++ b/src/libtraci/Vehicle.cpp
@@ -857,11 +857,11 @@ Vehicle::setSpeed(const std::string& vehID, double speed) {
 }
 
 void
-Vehicle::setPreviousSpeed(const std::string& vehID, double prevspeed, int timefactor) {
+Vehicle::setPreviousSpeed(const std::string& vehID, double prevSpeed, double prevAcceleration) {
     tcpip::Storage content;
     StoHelp::writeCompound(content, 2);
-    StoHelp::writeTypedDouble(content, prevspeed);
-    StoHelp::writeTypedInt(content, timefactor);
+    StoHelp::writeTypedDouble(content, prevSpeed);
+    StoHelp::writeTypedDouble(content, prevAcceleration);
     Dom::set(libsumo::VAR_PREV_SPEED, vehID, &content);
 }
 

--- a/src/libtraci/Vehicle.cpp
+++ b/src/libtraci/Vehicle.cpp
@@ -857,8 +857,12 @@ Vehicle::setSpeed(const std::string& vehID, double speed) {
 }
 
 void
-Vehicle::setPreviousSpeed(const std::string& vehID, double prevspeed) {
-    Dom::setDouble(libsumo::VAR_PREV_SPEED, vehID, prevspeed);
+Vehicle::setPreviousSpeed(const std::string& vehID, double prevspeed, int timefactor) {
+    tcpip::Storage content;
+    StoHelp::writeCompound(content, 2);
+    StoHelp::writeTypedDouble(content, prevspeed);
+    StoHelp::writeTypedInt(content, timefactor);
+    Dom::set(libsumo::VAR_PREV_SPEED, vehID, &content);
 }
 
 void

--- a/src/microsim/MSVehicle.cpp
+++ b/src/microsim/MSVehicle.cpp
@@ -6755,10 +6755,10 @@ MSVehicle::getDriverState() const {
 
 
 void
-MSVehicle::setPreviousSpeed(double prevspeed) {
+MSVehicle::setPreviousSpeed(double prevspeed, int timefactor) {
     myState.mySpeed = MAX2(0., prevspeed);
     // also retcon acceleration
-    myAcceleration = SPEED2ACCEL(myState.mySpeed - myState.myPreviousSpeed);
+    myAcceleration = SPEED2ACCEL(myState.mySpeed - myState.myPreviousSpeed) / timefactor;
 }
 
 

--- a/src/microsim/MSVehicle.cpp
+++ b/src/microsim/MSVehicle.cpp
@@ -3952,7 +3952,7 @@ MSVehicle::executeMove() {
 
 //#ifdef DEBUG_EXEC_MOVE
 //    if (DEBUG_COND) {
-//    	std::cout << "vSafe = " << toString(vSafe,12) << "\n" << std::endl;
+//        std::cout << "vSafe = " << toString(vSafe,12) << "\n" << std::endl;
 //    }
 //#endif
 
@@ -6755,10 +6755,14 @@ MSVehicle::getDriverState() const {
 
 
 void
-MSVehicle::setPreviousSpeed(double prevspeed, int timefactor) {
-    myState.mySpeed = MAX2(0., prevspeed);
+MSVehicle::setPreviousSpeed(double prevSpeed, double prevAcceleration) {
+    myState.mySpeed = MAX2(0., prevSpeed);
     // also retcon acceleration
-    myAcceleration = SPEED2ACCEL(myState.mySpeed - myState.myPreviousSpeed) / timefactor;
+    if (prevAcceleration != std::numeric_limits<int>::min()) {
+        myAcceleration = prevAcceleration;
+    } else {
+        myAcceleration = SPEED2ACCEL(myState.mySpeed - myState.myPreviousSpeed);
+    }
 }
 
 

--- a/src/microsim/MSVehicle.h
+++ b/src/microsim/MSVehicle.h
@@ -474,9 +474,9 @@ public:
 
     /** @brief Sets the influenced previous speed
      * @param[in] A double value with the speed that overwrites the previous speed
-     * @param[in] Number of time steps for the calculation of the acceleration
+     * @param[in] A double value with the acceleration that overwrites the previous acceleration
      */
-    void setPreviousSpeed(double prevspeed, int timefactor);
+    void setPreviousSpeed(double prevSpeed, double prevAcceleration);
 
 
     /** @brief Returns the vehicle's acceleration in m/s

--- a/src/microsim/MSVehicle.h
+++ b/src/microsim/MSVehicle.h
@@ -474,8 +474,9 @@ public:
 
     /** @brief Sets the influenced previous speed
      * @param[in] A double value with the speed that overwrites the previous speed
+     * @param[in] Number of time steps for the calculation of the acceleration
      */
-    void setPreviousSpeed(double prevspeed);
+    void setPreviousSpeed(double prevspeed, int timefactor);
 
 
     /** @brief Returns the vehicle's acceleration in m/s

--- a/src/traci-server/TraCIServerAPI_Vehicle.cpp
+++ b/src/traci-server/TraCIServerAPI_Vehicle.cpp
@@ -857,11 +857,27 @@ TraCIServerAPI_Vehicle::processSet(TraCIServer& server, tcpip::Storage& inputSto
             }
             break;
             case libsumo::VAR_PREV_SPEED: {
+                if (inputStorage.readUnsignedByte() != libsumo::TYPE_COMPOUND) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "Setting previous speed needs a compound object description.", outputStorage);
+                }
+                if (inputStorage.readInt() != 2) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "Setting previous speed needs a compound object description of two items.", outputStorage);
+                }
                 double prevspeed = 0;
                 if (!server.readTypeCheckingDouble(inputStorage, prevspeed)) {
-                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "Setting previous speed requires a double.", outputStorage);
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "The first previous speed parameter must be the speed given as a double.", outputStorage);
                 }
-                libsumo::Vehicle::setPreviousSpeed(id, prevspeed);
+                if (prevspeed < 0) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "Previous speed must not be negative.", outputStorage);
+                }
+                int timefactor = 0;
+                if (!server.readTypeCheckingInt(inputStorage, timefactor)) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "The second previous speed parameter must be the timefactor given as an integer.", outputStorage);
+                }
+                if (timefactor < 1) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "The timefactor must be a positive integer.", outputStorage);
+                }
+                libsumo::Vehicle::setPreviousSpeed(id, prevspeed, timefactor);
             }
             break;
             case libsumo::VAR_SPEEDSETMODE: {

--- a/src/traci-server/TraCIServerAPI_Vehicle.cpp
+++ b/src/traci-server/TraCIServerAPI_Vehicle.cpp
@@ -861,23 +861,20 @@ TraCIServerAPI_Vehicle::processSet(TraCIServer& server, tcpip::Storage& inputSto
                     return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "Setting previous speed needs a compound object description.", outputStorage);
                 }
                 if (inputStorage.readInt() != 2) {
-                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "Setting previous speed needs a compound object description of two items.", outputStorage);
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "Setting previous speed needs a compound object description of one or two items.", outputStorage);
                 }
-                double prevspeed = 0;
-                if (!server.readTypeCheckingDouble(inputStorage, prevspeed)) {
+                double prevSpeed = 0;
+                if (!server.readTypeCheckingDouble(inputStorage, prevSpeed)) {
                     return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "The first previous speed parameter must be the speed given as a double.", outputStorage);
                 }
-                if (prevspeed < 0) {
+                if (prevSpeed < 0) {
                     return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "Previous speed must not be negative.", outputStorage);
                 }
-                int timefactor = 0;
-                if (!server.readTypeCheckingInt(inputStorage, timefactor)) {
-                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "The second previous speed parameter must be the timefactor given as an integer.", outputStorage);
+                double prevAcceleration = 0;
+                if (!server.readTypeCheckingDouble(inputStorage, prevAcceleration)) {
+                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "The second previous speed parameter must be the acceleration given as an double.", outputStorage);
                 }
-                if (timefactor < 1) {
-                    return server.writeErrorStatusCmd(libsumo::CMD_SET_VEHICLE_VARIABLE, "The timefactor must be a positive integer.", outputStorage);
-                }
-                libsumo::Vehicle::setPreviousSpeed(id, prevspeed, timefactor);
+                libsumo::Vehicle::setPreviousSpeed(id, prevSpeed, prevAcceleration);
             }
             break;
             case libsumo::VAR_SPEEDSETMODE: {

--- a/src/utils/traci/TraCIAPI.cpp
+++ b/src/utils/traci/TraCIAPI.cpp
@@ -2863,14 +2863,14 @@ TraCIAPI::VehicleScope::setSpeed(const std::string& vehicleID, double speed) con
 }
 
 void
-TraCIAPI::VehicleScope::setPreviousSpeed(const std::string& vehicleID, double prevspeed, int timefactor) const {
+TraCIAPI::VehicleScope::setPreviousSpeed(const std::string& vehicleID, double prevSpeed, double prevAcceleration) const {
     tcpip::Storage content;
     content.writeUnsignedByte(libsumo::TYPE_COMPOUND);
     content.writeInt(2);
     content.writeUnsignedByte(libsumo::TYPE_DOUBLE);
-    content.writeDouble(prevspeed);
-    content.writeUnsignedByte(libsumo::TYPE_INTEGER);
-    content.writeInt(timefactor);
+    content.writeDouble(prevSpeed);
+    content.writeUnsignedByte(libsumo::TYPE_DOUBLE);
+    content.writeDouble(prevAcceleration);
     myParent.createCommand(libsumo::CMD_SET_VEHICLE_VARIABLE, libsumo::VAR_PREV_SPEED, vehicleID, &content);
     myParent.processSet(libsumo::CMD_SET_VEHICLE_VARIABLE);
 }

--- a/src/utils/traci/TraCIAPI.cpp
+++ b/src/utils/traci/TraCIAPI.cpp
@@ -2863,10 +2863,14 @@ TraCIAPI::VehicleScope::setSpeed(const std::string& vehicleID, double speed) con
 }
 
 void
-TraCIAPI::VehicleScope::setPreviousSpeed(const std::string& vehicleID, double prevspeed) const {
+TraCIAPI::VehicleScope::setPreviousSpeed(const std::string& vehicleID, double prevspeed, int timefactor) const {
     tcpip::Storage content;
+    content.writeUnsignedByte(libsumo::TYPE_COMPOUND);
+    content.writeInt(2);
     content.writeUnsignedByte(libsumo::TYPE_DOUBLE);
     content.writeDouble(prevspeed);
+    content.writeUnsignedByte(libsumo::TYPE_INTEGER);
+    content.writeInt(timefactor);
     myParent.createCommand(libsumo::CMD_SET_VEHICLE_VARIABLE, libsumo::VAR_PREV_SPEED, vehicleID, &content);
     myParent.processSet(libsumo::CMD_SET_VEHICLE_VARIABLE);
 }

--- a/src/utils/traci/TraCIAPI.h
+++ b/src/utils/traci/TraCIAPI.h
@@ -673,7 +673,7 @@ public:
         void slowDown(const std::string& vehicleID, double speed, double duration) const;
         void openGap(const std::string& vehicleID, double newTau, double duration, double changeRate, double maxDecel) const;
         void setSpeed(const std::string& vehicleID, double speed) const;
-        void setPreviousSpeed(const std::string& vehicleID, double prevspeed) const;
+        void setPreviousSpeed(const std::string& vehicleID, double prevspeed, int timefactor) const;
         void setLaneChangeMode(const std::string& vehicleID, int mode) const;
         void setSpeedMode(const std::string& vehicleID, int mode) const;
         void setStop(const std::string vehicleID, const std::string edgeID, const double endPos = 1.,

--- a/src/utils/traci/TraCIAPI.h
+++ b/src/utils/traci/TraCIAPI.h
@@ -673,7 +673,7 @@ public:
         void slowDown(const std::string& vehicleID, double speed, double duration) const;
         void openGap(const std::string& vehicleID, double newTau, double duration, double changeRate, double maxDecel) const;
         void setSpeed(const std::string& vehicleID, double speed) const;
-        void setPreviousSpeed(const std::string& vehicleID, double prevspeed, int timefactor) const;
+        void setPreviousSpeed(const std::string& vehicleID, double prevSpeed, double prevAcceleration = std::numeric_limits<int>::min()) const;
         void setLaneChangeMode(const std::string& vehicleID, int mode) const;
         void setSpeedMode(const std::string& vehicleID, int mode) const;
         void setStop(const std::string vehicleID, const std::string edgeID, const double endPos = 1.,


### PR DESCRIPTION
I use setPreviousSpeed in scenarios in which a SUMO-vehicle is controlled by another program (another SUMO instance or a third-party program like Simulink).
When a program with higher timesteps forces a SUMO-vehicle to a specific speed (with setPreviousSpeed), the acceleration is calculated as if the vehicle had only changed the speed over its last timestep (but the other simulation changed the speed over a longer period with a lower decel/accel). The results are hard accelerating/braking maneuvers and create issues with the EIDM.
Therefore, I added the parameter "timefactor" to manipulate the acceleration calculation. Old behavior is timefactor=1.

Signed-off-by: Dominik Salles <dominik.salles@fkfs.de>