### PR TITLE
Added support for known color strings in sumolib's XML color decoding

### DIFF
--- a/tools/sumolib/color.py
+++ b/tools/sumolib/color.py
@@ -34,4 +34,21 @@ class RGBAColor:
 
 
 def decodeXML(c):
-    return RGBAColor(*[float(x) for x in c.split(",")])
+    colorSwitch = {
+            "red": RGBAColor(255, 0, 0, 255),
+            "green": RGBAColor(0, 255, 0, 255),
+            "blue": RGBAColor(0, 0, 255, 255),
+            "yellow": RGBAColor(255, 255, 0, 255),
+            "cyan": RGBAColor(0, 255, 255, 255),
+            "magenta": RGBAColor(255, 0, 255, 255),
+            "orange": RGBAColor(255, 128, 0, 255),
+            "white": RGBAColor(255, 255, 255, 255),
+            "black": RGBAColor(0, 0, 0, 255),
+            "grey": RGBAColor(128, 128, 128, 255),
+            "gray": RGBAColor(128, 128, 128, 255),
+            "invisible": RGBAColor(0, 0, 0, 0)
+            }
+    knownColor = colorSwitch.get(c)
+    if knownColor is None:
+        return RGBAColor(*[float(x) for x in c.split(",")])
+    return knownColor


### PR DESCRIPTION
The missing support led to errors when parsing e.g. polygons with colors defined as "red", "grey", etc.

Signed-off-by: Alexander Brummer <alexander.brummer@fau.de>