### PR TITLE
Color 3D vehicles themselves and remove bubble #5735

### DIFF
--- a/src/osgview/GUIOSGBuilder.cpp
+++ b/src/osgview/GUIOSGBuilder.cpp
@@ -14,6 +14,7 @@
 /// @file    GUIOSGBuilder.cpp
 /// @author  Daniel Krajzewicz
 /// @author  Michael Behrisch
+/// @author  Mirko Barthauer
 /// @date    19.01.2012
 ///
 // Builds OSG nodes from microsim objects
@@ -348,6 +349,13 @@ GUIOSGBuilder::buildMovable(const MSVehicleType& type) {
                                   type.getHeight() / (bbox.zMax() - bbox.zMin())));
         m.pos->addChild(base);
         enlarge = type.getMinGap() / 2.;
+
+        // material for coloring the vehicle body
+        m.mat = new osg::Material();
+        osg::ref_ptr<osg::StateSet> ss = base->getOrCreateStateSet();
+        ss->setAttribute(m.mat, osg::StateAttribute::ON | osg::StateAttribute::OVERRIDE | osg::StateAttribute::PROTECTED);
+        ss->setRenderingHint(osg::StateSet::TRANSPARENT_BIN);
+        ss->setMode(GL_BLEND, osg::StateAttribute::OVERRIDE | osg::StateAttribute::PROTECTED | osg::StateAttribute::ON);
     }
     m.lights = new osg::Switch();
     for (double offset = -0.3; offset < 0.5; offset += 0.6) {
@@ -379,11 +387,7 @@ GUIOSGBuilder::buildMovable(const MSVehicleType& type) {
     setShapeState(brake);
     m.lights->addChild(geode);
 
-    geode = new osg::Geode();
     osg::Vec3d center(0, type.getLength() / 2., type.getHeight() / 2.);
-    m.geom = new osg::ShapeDrawable(new osg::Sphere(center, .5f));
-    geode->addDrawable(m.geom);
-    setShapeState(m.geom);
     osg::PositionAttitudeTransform* ellipse = new osg::PositionAttitudeTransform();
     ellipse->addChild(geode);
     ellipse->addChild(m.lights);

--- a/src/osgview/GUIOSGHeader.h
+++ b/src/osgview/GUIOSGHeader.h
@@ -46,6 +46,7 @@
 #include <osg/Group>
 #include <osg/Light>
 #include <osg/LightSource>
+#include <osg/Material>
 #include <osg/Node>
 #include <osg/PositionAttitudeTransform>
 #include <osg/Sequence>

--- a/src/osgview/GUIOSGView.cpp
+++ b/src/osgview/GUIOSGView.cpp
@@ -361,7 +361,7 @@ GUIOSGView::onPaint(FXObject*, FXSelector, void*) {
         n->setUpdateCallback(new osg::AnimationPathCallback(path));
         */
         const RGBColor& col = myVisualizationSettings->vehicleColorer.getScheme().getColor(veh->getColorValue(*myVisualizationSettings, myVisualizationSettings->vehicleColorer.getActive()));
-        myVehicles[veh].geom->setColor(osg::Vec4d(col.red() / 255., col.green() / 255., col.blue() / 255., col.alpha() / 255.));
+        myVehicles[veh].mat->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4d(col.red() / 255., col.green() / 255., col.blue() / 255., col.alpha() / 255.));
         myVehicles[veh].lights->setValue(0, veh->signalSet(MSVehicle::VEH_SIGNAL_BLINKER_RIGHT | MSVehicle::VEH_SIGNAL_BLINKER_EMERGENCY));
         myVehicles[veh].lights->setValue(1, veh->signalSet(MSVehicle::VEH_SIGNAL_BLINKER_LEFT | MSVehicle::VEH_SIGNAL_BLINKER_EMERGENCY));
         myVehicles[veh].lights->setValue(2, veh->signalSet(MSVehicle::VEH_SIGNAL_BRAKELIGHT));

--- a/src/osgview/GUIOSGView.h
+++ b/src/osgview/GUIOSGView.h
@@ -110,6 +110,7 @@ public:
     struct OSGMovable {
         osg::ref_ptr<osg::PositionAttitudeTransform> pos;
         osg::ref_ptr<osg::ShapeDrawable> geom;
+        osg::ref_ptr<osg::Material> mat;
         osg::ref_ptr<osg::Switch> lights;
         bool active;
     };


### PR DESCRIPTION
This pull request changes how vehicles are displayed in the 3D OpenSceneGraph view. It removes the bubbles previously used for color scheme purpose and instead colors the vehicles directly. 

- If the 3D model uses textures, the color is blended over. 
- If the color scheme uses transparency, the transparency applies to the whole 3D model. 
- The whole 3D model is colored, including e.g. the tyres 

Current vehicle type parameter defaults guarantee every vehicle type has a default 3D model assigned, even though a passenger car might not make much sense in some cases.

Signed-off-by: m-kro <m.barthauer@t-online.de>