### PR TITLE
Set view angle for OSG view fix #5663

### DIFF
--- a/src/osgview/GUIOSGView.h
+++ b/src/osgview/GUIOSGView.h
@@ -194,7 +194,7 @@ private:
     public:
         SUMOTerrainManipulator() {
             setAllowThrow(false);
-            setRotationMode(ELEVATION_AZIM_ROLL); // default is ELEVATION_AZIM and this prevents rotating the view around the z-axis
+            setVerticalAxisFixed(false);
         }
         bool performMovementLeftMouseButton(const double eventTimeDelta, const double dx, const double dy) {
             return osgGA::TerrainManipulator::performMovementMiddleMouseButton(eventTimeDelta, dx, dy);
@@ -249,7 +249,7 @@ protected:
 
 private:
     GUIVehicle* myTracked;
-    osg::ref_ptr<osgGA::CameraManipulator> myCameraManipulator;
+    osg::ref_ptr<SUMOTerrainManipulator> myCameraManipulator;
 
     SUMOTime myLastUpdate;
 


### PR DESCRIPTION
This implements the roll rotation of the OSG view. The current angle is shown in the viewport dialog and changes are applied to the view. According to the [OSG documentation](https://github.com/openscenegraph/OpenSceneGraph/blob/683403244a489fe3e71f1533580c22e099774a36/src/osgGA/TerrainManipulator.cpp#L40-L46), I replaced the call to setRotationMode with setVerticalAxisFixed. 

Signed-off-by: m-kro <m.barthauer@t-online.de>