### PR TITLE
Hide 3D view options in 2D view fix #10540

### DIFF
--- a/src/osgview/GUIOSGView.cpp
+++ b/src/osgview/GUIOSGView.cpp
@@ -187,6 +187,12 @@ GUIOSGView::recalculateBoundaries() {
 }
 
 
+bool
+GUIOSGView::is3DView() const {
+    return true;
+}
+
+
 void
 GUIOSGView::buildViewToolBars(GUIGlChildWindow* v) {
     // build coloring tools

--- a/src/osgview/GUIOSGView.h
+++ b/src/osgview/GUIOSGView.h
@@ -126,6 +126,9 @@ public:
     /// @brief recalculate boundaries
     void recalculateBoundaries();
 
+    /// @brief confirm 3D view to viewport editor
+    bool is3DView() const;
+
     /// @brief builds the view toolbars
     virtual void buildViewToolBars(GUIGlChildWindow*);
 

--- a/src/utils/gui/windows/GUIDialog_EditViewport.cpp
+++ b/src/utils/gui/windows/GUIDialog_EditViewport.cpp
@@ -118,12 +118,13 @@ GUIDialog_EditViewport::GUIDialog_EditViewport(GUISUMOAbstractView* parent, cons
     new FXLabel(lookAtZFrame, "LookAtZ:", nullptr, GUIDesignLabelLeftThick);
     myLookAtZ = new FXRealSpinner(lookAtZFrame, 16, this, MID_CHANGED, GUIDesignSpinDialViewPort);
 
-    // only show LookAt elements if OSG is enabled
-#ifdef HAVE_OSG
-    lookAtFrame->show();
-#else
-    lookAtFrame->hide();
-#endif
+    // only show LookAt elements for OSG views
+    if (parent->is3DView()) {
+        lookAtFrame->show();
+    }
+    else {
+        lookAtFrame->hide();
+    }
 
     // create buttons ok/cancel
     new FXHorizontalSeparator(contentsFrame, GUIDesignHorizontalSeparator);

--- a/src/utils/gui/windows/GUISUMOAbstractView.cpp
+++ b/src/utils/gui/windows/GUISUMOAbstractView.cpp
@@ -269,6 +269,12 @@ GUISUMOAbstractView::getVisibleBoundary() const {
 }
 
 
+bool
+GUISUMOAbstractView::is3DView() const {
+    return false;
+}
+
+
 void
 GUISUMOAbstractView::paintGL() {
     if (getWidth() == 0 || getHeight() == 0) {

--- a/src/utils/gui/windows/GUISUMOAbstractView.h
+++ b/src/utils/gui/windows/GUISUMOAbstractView.h
@@ -139,6 +139,9 @@ public:
     /// @brief get visible boundary
     Boundary getVisibleBoundary() const;
 
+    /// @brief return whether this is a 3D view
+    virtual bool is3DView() const;
+
     /// @brief mouse functions
     //@{
     virtual long onConfigure(FXObject*, FXSelector, void*);


### PR DESCRIPTION
This fixes issue #10540 . It replaces the conditional macro statement about OSG support with a normal condition to hide the lookAt input fields in the viewport editor when created for a 2D view.
Signed-off-by: m-kro <m.barthauer@t-online.de>