### PR TITLE
Update viewport dialog when moving the OSG 3D view

### DIFF
--- a/src/osgview/GUIOSGView.h
+++ b/src/osgview/GUIOSGView.h
@@ -193,6 +193,8 @@ public:
     long OnIdle(FXObject* sender, FXSelector sel, void* ptr);
 
 private:
+    double calculateRotation(const osg::Vec3d& lookFrom, const osg::Vec3d& lookAt, const osg::Vec3d& up);
+
     class SUMOTerrainManipulator : public osgGA::TerrainManipulator {
     public:
         SUMOTerrainManipulator() {


### PR DESCRIPTION
In the 2D view, coordinates in the viewport dialog are updated when the user changes the view directly. The 3D view however would not forward changed coordinates to an open viewport dialog. This pull request adds the coordinate update call for the 3D view. 

Signed-off-by: m-kro <m.barthauer@t-online.de>