### PR TITLE
Fix unclosed socket in TraCI `Connection` initializer

### DIFF
--- a/tools/traci/connection.py
+++ b/tools/traci/connection.py
@@ -52,9 +52,9 @@ class Connection(StepManager):
         self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         try:
             self._socket.connect((host, port))
-        except socket.error as e:
+        except socket.error:
             self._socket.close()
-            raise e
+            raise
         self._process = process
         self._string = bytes()
         self._queue = []

--- a/tools/traci/connection.py
+++ b/tools/traci/connection.py
@@ -50,7 +50,11 @@ class Connection(StepManager):
         else:
             self._socket = socket.socket()
         self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-        self._socket.connect((host, port))
+        try:
+            self._socket.connect((host, port))
+        except socket.error as e:
+            self._socket.close()
+            raise e
         self._process = process
         self._string = bytes()
         self._queue = []


### PR DESCRIPTION
## Solution
I propose a minor fix to eliminate a resource warning originating from the `traci.Connection` initializer.

The second client example in the `socket` Python library documentation indicates that `socket.connect()` may not clean itself up if it generates an exception: https://docs.python.org/3.5/library/socket.html#example

```python
# Echo client program
...
    try:
        s.connect(sa)
    except OSError as msg:
        s.close()
        s = None
        continue
    break
...
```
## Impact

Using `traci.connect()` would cause an unclosed socket to get garbage collected and give a resource warning. The error is known about and caught at the `traci.connect()` level without clean-up of the socket.

https://github.com/eclipse/sumo/blob/49ba1525d34ae23b515d08cf2643975a1f7b169c/tools/traci/main.py#L89-L111

It was causing warnings to show up and mess with logging, requiring a workaround. A stranger quickly reached out to make it known that the issue was not unique to us: https://github.com/huawei-noah/SMARTS/issues/1373

