### PR TITLE
Show vehicle context menu in OSG fix #10191

### DIFF
--- a/src/osgview/GUIOSGView.h
+++ b/src/osgview/GUIOSGView.h
@@ -13,6 +13,7 @@
 /****************************************************************************/
 /// @file    GUIOSGView.h
 /// @author  Daniel Krajzewicz
+/// @author  Mirko Barthauer
 /// @date    19.01.2012
 ///
 // An OSG-based 3D view on the simulation
@@ -244,6 +245,17 @@ private:
         GUISUMOAbstractView* const myParent;
         FXCursor* const myOldCursor;
     };
+
+	class PickHandler : public osgGA::GUIEventHandler {
+	public:
+		PickHandler(GUISUMOAbstractView* parent) : myParent(parent) {};
+		bool handle(const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter& aa);
+		virtual void pick(osgViewer::View* view, const osgGA::GUIEventAdapter& ea);
+	protected:
+		~PickHandler() {};
+	private:
+		GUISUMOAbstractView* const myParent;
+	};
 
 protected:
     GUIOSGView() {}


### PR DESCRIPTION
This adds the context menu for vehicles in the OSG 3D view. Not all options from the context menu are already implemented in 3D - e.g. tracking works, displaying routes is still missing. 

Signed-off-by: m-kro <m.barthauer@t-online.de>