### PR TITLE
Switching between steering modes in the racing game

### DIFF
--- a/tools/game/racing.py
+++ b/tools/game/racing.py
@@ -26,6 +26,7 @@ import os
 import sys
 import threading
 import math
+import argparse
 
 if sys.version_info.major == 3:
     import queue as Queue
@@ -234,7 +235,17 @@ def main(sumocfg="racing/racing.sumocfg", egoID="ego"):
     root.mainloop()
 
 
-if len(sys.argv) < 3:
-    main(*sys.argv[1:])
+# Argument parser
+parser = argparse.ArgumentParser()
+parser.add_argument('--sumocfg', default="racing/racing.sumocfg", help = ".sumocfg file path", required=False)
+parser.add_argument('--ego', default = "ego", help = "vehicle ego id", required=False)
+parser.add_argument('--mouse', default = "no", help = "mouse features' toggle switch - possible choices are y and n (default).", required=False)
+args = parser.parse_args()
+
+if len(sys.argv) < 4:
+        # Disabling mouse control unless explicitly mentioned
+        if args.mouse != 'yes':
+            autopy = None 
+        main(args.sumocfg, args.ego)
 else:
-    print("racing.py <sumocfg> [<egoID>]")
+    print("racing.py --sumocfg=<sumocfg> [--ego=<egoID>] [--mouse=<yes/no>]")


### PR DESCRIPTION
In this PR, the following features have been implemented:

- A new format for argument parsing in the racing game (using `optparse`). Care has been taken to restore all default parameters.
- Changing the steering mode through command-line arguments

Relevant issue(s): https://github.com/eclipse/sumo/issues/10783