### PR TITLE
New unit tests for the Boundary class

### DIFF
--- a/src/utils/geom/Boundary.cpp
+++ b/src/utils/geom/Boundary.cpp
@@ -365,10 +365,16 @@ Boundary::operator!=(const Boundary& b) const {
 
 void
 Boundary::set(double xmin, double ymin, double xmax, double ymax) {
-    myXmin = xmin;
-    myYmin = ymin;
-    myXmax = xmax;
-    myYmax = ymax;
+    /*
+        Takes care of the following extraneous cases w.r.t the given parameters:
+            - xmin > xmax
+            - ymin > ymax
+    */
+    
+    myXmin = std::min(xmin, xmax);
+    myYmin = std::min(ymin, ymax);
+    myXmax = std::max(xmin, xmax);;
+    myYmax = std::max(ymin, ymax);;
 }
 
 

--- a/src/utils/geom/Boundary.cpp
+++ b/src/utils/geom/Boundary.cpp
@@ -297,6 +297,7 @@ Boundary::partialWithin(const AbstractPoly& poly, double offset) const {
 
 Boundary&
 Boundary::grow(double by) {
+
     myXmax += by;
     myYmax += by;
     myXmin -= by;
@@ -366,7 +367,7 @@ Boundary::operator!=(const Boundary& b) const {
 void
 Boundary::set(double xmin, double ymin, double xmax, double ymax) {
     /*
-        Takes care of the following extraneous cases w.r.t the given parameters:
+        Takes care of the following extraneous cases w.r.t the input parameters:
             - xmin > xmax
             - ymin > ymax
     */

--- a/unittest/src/utils/geom/BoundaryTest.cpp
+++ b/unittest/src/utils/geom/BoundaryTest.cpp
@@ -119,18 +119,20 @@ TEST(Boundary, test_method_moveby) {
     EXPECT_DOUBLE_EQ(bound.ymin(), -1.5);
 }
 
+
+
 /* Test the method 'growWidth'*/
 TEST(Boundary, test_method_growWidth){
     Boundary bound(1, 2, 3, 6);
     bound.growWidth(0.5);
     EXPECT_DOUBLE_EQ(bound.xmin(), 0.5);
-    EXPECT_DOUBLE_EQ(bound.xmax(), 2.5);
+    EXPECT_DOUBLE_EQ(bound.xmax(), 3.5);
 }
 
 /* Test the method 'growHeight'*/
 TEST(Boundary, test_method_growHeight){
     Boundary bound(1, 2, 3, 6);
     bound.growHeight(0.5);
-    EXPECT_DOUBLE_EQ(bound.ymin(), 3.5);
-    EXPECT_DOUBLE_EQ(bound.ymax(), 5.5);
+    EXPECT_DOUBLE_EQ(bound.ymin(), 1.5);
+    EXPECT_DOUBLE_EQ(bound.ymax(), 6.5);
 }

--- a/unittest/src/utils/geom/BoundaryTest.cpp
+++ b/unittest/src/utils/geom/BoundaryTest.cpp
@@ -27,7 +27,7 @@
 /* Test the method 'add'*/
 TEST(Boundary, test_method_add) {
     Boundary bound;
-    bound.add(1, 2);
+    bound.add(1, 2); // Will work for bound.add(2,1) too
     EXPECT_DOUBLE_EQ(bound.xmax(), 1);
     EXPECT_DOUBLE_EQ(bound.xmin(), 1);
     EXPECT_DOUBLE_EQ(bound.ymax(), 2);
@@ -117,4 +117,20 @@ TEST(Boundary, test_method_moveby) {
     EXPECT_DOUBLE_EQ(bound.xmin(), 3.5);
     EXPECT_DOUBLE_EQ(bound.ymax(), 2.5);
     EXPECT_DOUBLE_EQ(bound.ymin(), -1.5);
+}
+
+/* Test the method 'growWidth'*/
+TEST(Boundary, test_method_growWidth){
+    Boundary bound(1, 2, 3, 6);
+    bound.growWidth(0.5);
+    EXPECT_DOUBLE_EQ(bound.xmin(), 0.5);
+    EXPECT_DOUBLE_EQ(bound.xmax(), 2.5);
+}
+
+/* Test the method 'growHeight'*/
+TEST(Boundary, test_method_growHeight){
+    Boundary bound(1, 2, 3, 6);
+    bound.growHeight(0.5);
+    EXPECT_DOUBLE_EQ(bound.ymin(), 3.5);
+    EXPECT_DOUBLE_EQ(bound.ymax(), 5.5);
 }


### PR DESCRIPTION
In this PR, the following functionalities have been added:
- Ensuring that the right parameters are updated in the `Boundary::set()` function.
- New unit tests for the `Boundary` class' `growWidth()` and `growHeight()` methods.
- Documentation conforming to the current tests' implementation.

Note:
In the `grow()`,  `growWidth()` and `growHeight()` functions, we need not check if `by >= 0` and negate `by` if not, as one can view this operation as "shrinking" the boundary. 