### PR TITLE
[tools/randomTrips] Made possible argument forwarding to duarouter (#7347).

### DIFF
--- a/tools/randomTrips.py
+++ b/tools/randomTrips.py
@@ -1,3 +1,4 @@
+
 #!/usr/bin/env python
 # Eclipse SUMO, Simulation of Urban MObility; see https://eclipse.org/sumo
 # Copyright (C) 2010-2022 German Aerospace Center (DLR) and others.
@@ -628,7 +629,13 @@ def main(options):
     if not options.verbose:
         args += ['--no-warnings']
     else:
-        args += ['-v']
+        args += ['--verbose']
+    
+    duarouter_options = sumolib.options.assign_remaining_args(DUAROUTER, "duarouter", options.remaining_args)
+    duarouter_options = [[duarouter_options[i], duarouter_options[i+1]] for i in range(0, len(duarouter_options)-1, 2)]
+    for arg in duarouter_options:
+        if arg[0] not in args:
+            args += arg
 
     if options.routefile:
         args2 = args + ['-o', options.routefile]

--- a/tools/randomTrips.py
+++ b/tools/randomTrips.py
@@ -631,11 +631,12 @@ def main(options):
     else:
         args += ['--verbose']
     
-    duarouter_options = sumolib.options.assign_remaining_args(DUAROUTER, "duarouter", options.remaining_args)
-    duarouter_options = [[duarouter_options[i], duarouter_options[i+1]] for i in range(0, len(duarouter_options)-1, 2)]
-    for arg in duarouter_options:
-        if arg[0] not in args:
-            args += arg
+    if options.remaining_args:
+        duarouter_options = sumolib.options.assign_remaining_args(DUAROUTER, "duarouter", options.remaining_args)
+        duarouter_options = [[duarouter_options[i], duarouter_options[i+1]] for i in range(0, len(duarouter_options)-1, 2)]
+        for arg in duarouter_options:
+            if arg[0] not in args:
+                args += arg
 
     if options.routefile:
         args2 = args + ['-o', options.routefile]

--- a/tools/sumolib/options.py
+++ b/tools/sumolib/options.py
@@ -241,9 +241,9 @@ class ArgumentParser(argparse.ArgumentParser):
             # Not prefixed args at that stage are unrecognized while prefixed ones
             # will be analyzed downstream with the help of the assign_remaining_args function.
             unrecognized_args = []
-            for idx, arg in enumerate(args.remaining_args):
+            for arg in args.remaining_args:
                 if arg.split('--')[0] == '':
-                        unrecognized_args += [args.remaining_args[idx], args.remaining_args[idx+1]]                
+                        unrecognized_args += [arg]                
             
             if unrecognized_args:
                 self.error('unrecognized arguments: %s' % ' '.join(unrecognized_args))

--- a/tools/sumolib/options.py
+++ b/tools/sumolib/options.py
@@ -247,6 +247,8 @@ class ArgumentParser(argparse.ArgumentParser):
             
             if unrecognized_args:
                 self.error('unrecognized arguments: %s' % ' '.join(unrecognized_args))
+        else:
+            args.remaining_args = None
         if _OPTIONS[0] is None:
             # only save the "outermost" option instance
             _OPTIONS[0] = args


### PR DESCRIPTION
In randomTrips.py, some arguments were already forwarded to duarouter internally. Now a user can also forward arguments to duarouter without changing randomTrips.py. For this, it is necessary to prefix the argument passed to randomTrips with "duarouter", for example "duarouter--exit-times".