### PR TITLE
Zoom along the view axis in OSG 3D view ref #10791

### DIFF
--- a/src/osgview/GUIOSGView.h
+++ b/src/osgview/GUIOSGView.h
@@ -193,6 +193,9 @@ public:
     long onPaint(FXObject*, FXSelector, void*);
     long OnIdle(FXObject* sender, FXSelector sel, void* ptr);
 
+	// @brief get the new camera position given a zoom value
+	void zoom2Pos(double zoom, Position& camera, Position& lookAt) const;
+
 private:
     double calculateRotation(const osg::Vec3d& lookFrom, const osg::Vec3d& lookAt, const osg::Vec3d& up);
 
@@ -265,7 +268,9 @@ protected:
     osg::ref_ptr<osg::Group> myRoot;
 
 private:
-    GUIVehicle* myTracked;
+	double myZoomRefLength;
+	
+	GUIVehicle* myTracked;
     osg::ref_ptr<SUMOTerrainManipulator> myCameraManipulator;
 
     SUMOTime myLastUpdate;

--- a/src/utils/gui/windows/GUIDialog_EditViewport.cpp
+++ b/src/utils/gui/windows/GUIDialog_EditViewport.cpp
@@ -33,6 +33,7 @@
 #include <utils/options/OptionsCont.h>
 
 #include "GUISUMOAbstractView.h"
+#include "osgview/GUIOSGView.h"
 #include "GUIDialog_EditViewport.h"
 
 
@@ -185,7 +186,20 @@ GUIDialog_EditViewport::onCmdChanged(FXObject* o, FXSelector, void*) {
     if (o == myZOff) {
         myZoom->setValue(myParent->getChanger().zPos2Zoom(myZOff->getValue()));
     } else if (o == myZoom) {
-        myZOff->setValue(myParent->getChanger().zoom2ZPos(myZoom->getValue()));
+		if (myParent->is3DView()) {
+			// calculate new camera position
+			Position camera, lookAt;
+			dynamic_cast<GUIOSGView*>(myParent)->zoom2Pos(myZoom->getValue(), camera, lookAt);
+			myXOff->setValue(camera.x());
+			myYOff->setValue(camera.y());
+			myZOff->setValue(camera.z());
+			myLookAtX->setValue(lookAt.x());
+			myLookAtY->setValue(lookAt.y());
+			myLookAtZ->setValue(lookAt.z());
+		}
+		else {
+			myZOff->setValue(myParent->getChanger().zoom2ZPos(myZoom->getValue()));
+		}
     }
     myParent->setViewportFromToRot(Position(myXOff->getValue(), myYOff->getValue(), myZOff->getValue()),
 #ifdef HAVE_OSG
@@ -274,7 +288,7 @@ GUIDialog_EditViewport::setValues(const Position& lookFrom, const Position& look
     myXOff->setValue(lookFrom.x());
     myYOff->setValue(lookFrom.y());
     myZOff->setValue(lookFrom.z());
-    myZoom->setValue(myParent->getChanger().zPos2Zoom(lookFrom.z()));
+	myZoom->setValue(myParent->getChanger().zPos2Zoom(lookFrom.z()));
 #ifdef HAVE_OSG
     myLookAtX->setValue(lookAt.x());
     myLookAtY->setValue(lookAt.y());


### PR DESCRIPTION
The 3D OSG view now recalculates the viewport coordinates (camera position and where to look at) when the zoom level is changed in the viewport dialog. The zoom level in the 3D view is defined the same way as in 2D: A zoom level of 100 is equal to a Z value of the network width and a higher zoom level means getting closer to the ground.

Caveat: If the camera is positioned in a parallel way to the ground, this concept does not work. In this case, a warning is issued.