### PR TITLE
Use default shape when car model cannot be loaded ref #10895

### DIFF
--- a/src/osgview/GUIOSGBuilder.cpp
+++ b/src/osgview/GUIOSGBuilder.cpp
@@ -379,7 +379,8 @@ GUIOSGBuilder::buildMovable(const MSVehicleType& type) {
     if (myCars.find(osgFile) == myCars.end()) {
         myCars[osgFile] = osgDB::readNodeFile(osgFile);
         if (myCars[osgFile] == 0) {
-            WRITE_ERROR("Could not load '" + osgFile + "'.");
+            WRITE_ERROR("Could not load '" + osgFile + "'. The model is replaced by a box shape.");
+			myCars[osgFile] = new osg::ShapeDrawable(new osg::Box(osg::Vec3d(0, 0, 0), 1.0f));
         }
     }
     osg::Node* carNode = myCars[osgFile];

--- a/src/osgview/GUIOSGBuilder.cpp
+++ b/src/osgview/GUIOSGBuilder.cpp
@@ -380,7 +380,12 @@ GUIOSGBuilder::buildMovable(const MSVehicleType& type) {
         myCars[osgFile] = osgDB::readNodeFile(osgFile);
         if (myCars[osgFile] == 0) {
             WRITE_ERROR("Could not load '" + osgFile + "'. The model is replaced by a box shape.");
-			myCars[osgFile] = new osg::ShapeDrawable(new osg::Box(osg::Vec3d(0, 0, 0), 1.0f));
+			osg::PositionAttitudeTransform* rot = new osg::PositionAttitudeTransform();
+			rot->addChild(new osg::ShapeDrawable(new osg::Cone(osg::Vec3d(0, 0, 0), 1.0f, 1.0f)));
+			rot->setAttitude(osg::Quat(osg::DegreesToRadians(90.), osg::Vec3(1, 0, 0),
+				0., osg::Vec3(0, 1, 0),
+				0., osg::Vec3(0, 0, 1)));
+			myCars[osgFile] = rot;
         }
     }
     osg::Node* carNode = myCars[osgFile];

--- a/src/osgview/GUIOSGView.cpp
+++ b/src/osgview/GUIOSGView.cpp
@@ -372,9 +372,7 @@ GUIOSGView::onPaint(FXObject*, FXSelector, void*) {
         n->setUpdateCallback(new osg::AnimationPathCallback(path));
         */
         const RGBColor& col = myVisualizationSettings->vehicleColorer.getScheme().getColor(veh->getColorValue(*myVisualizationSettings, myVisualizationSettings->vehicleColorer.getActive()));
-        if (myVehicles[veh].mat != nullptr) {
-            myVehicles[veh].mat->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4d(col.red() / 255., col.green() / 255., col.blue() / 255., col.alpha() / 255.));
-        }
+        myVehicles[veh].mat->setDiffuse(osg::Material::FRONT_AND_BACK, osg::Vec4d(col.red() / 255., col.green() / 255., col.blue() / 255., col.alpha() / 255.));
         myVehicles[veh].lights->setValue(0, veh->signalSet(MSVehicle::VEH_SIGNAL_BLINKER_RIGHT | MSVehicle::VEH_SIGNAL_BLINKER_EMERGENCY));
         myVehicles[veh].lights->setValue(1, veh->signalSet(MSVehicle::VEH_SIGNAL_BLINKER_LEFT | MSVehicle::VEH_SIGNAL_BLINKER_EMERGENCY));
         myVehicles[veh].lights->setValue(2, veh->signalSet(MSVehicle::VEH_SIGNAL_BRAKELIGHT));


### PR DESCRIPTION
Since removal of the big bubbles in #10227 , there was no fallback solution when a given car model file could not be loaded. Only an error message was issued. Now a box shape is drawn for vehicles with failing car model file. This should help in cases like #10895. 

Signed-off-by: m-kro <m.barthauer@t-online.de>