### PR TITLE
Boundary Checks for HSV Colour Values, Addition to `<<` operator

### DIFF
--- a/src/utils/common/RGBColor.cpp
+++ b/src/utils/common/RGBColor.cpp
@@ -154,6 +154,9 @@ operator<<(std::ostream& os, const RGBColor& col) {
     if (col == RGBColor::GREY) {
         return os << "grey";
     }
+    if (col == RGBColor::INVISIBLE){
+        return os << "invisible";
+    }
     os << static_cast<int>(col.myRed) << ","
        << static_cast<int>(col.myGreen) << ","
        << static_cast<int>(col.myBlue);
@@ -366,6 +369,9 @@ RGBColor::interpolate(const RGBColor& minColor, const RGBColor& maxColor, double
 
 RGBColor
 RGBColor::fromHSV(double h, double s, double v) {
+    h = MIN2((MAX2(h,0.0)),360.0);
+    s = MIN2((MAX2(s,0.0)),1.0);
+    v = MIN2((MAX2(v,0.0)),1.0);
     h /= 60.;
     const int i = int(floor(h));
     double f = h - i;


### PR DESCRIPTION
In this PR, the following functionalities have been implemented:
- Adding the `invisible` "built-in" colour to the custom `std::ostream` method of `RGBColor`
- Range checks for HSV colour values passed into the `fromHSV()` method, akin to checks done in the `interpolate` method 