### PR TITLE
[tools/randomTrips] Patches the trips file when the --validate option is used with randomTrips (#10973).

### DIFF
--- a/tools/randomTrips.py
+++ b/tools/randomTrips.py
@@ -27,6 +27,7 @@ import bisect
 import subprocess
 from collections import defaultdict
 import math
+import datetime
 
 if 'SUMO_HOME' in os.environ:
     sys.path.append(os.path.join(os.environ['SUMO_HOME'], 'tools'))
@@ -744,6 +745,14 @@ def main(options):
         sys.stdout.flush()
         os.remove(options.tripfile)  # on windows, rename does not overwrite
         os.rename(tmpTrips, options.tripfile)
+        
+        with open(options.tripfile, 'r') as fouttrips:
+            contents = fouttrips.readlines()
+        config = '\n<!-- generated on %s by %s %s\n%s-->' % (datetime.datetime.now(), os.path.basename(sys.argv[0]), sumolib.version.gitDescribe(), options.config_as_string)
+        contents.insert(1, config)
+        with open(options.tripfile, "w") as fouttrips:
+            contents = "".join(contents)
+            fouttrips.write(contents)
 
     if options.weights_outprefix:
         idPrefix = ""


### PR DESCRIPTION
The ´--validate´ option calls duarouter in the background to validate the trips. This resulted in the randomTrips configuration being overwritten in the trips file by the duarouter one. Now both configurations are inserted.