### PR TITLE
Add new CFModel-function maxNextSafeMin

### DIFF
--- a/src/microsim/MSVehicle.cpp
+++ b/src/microsim/MSVehicle.cpp
@@ -3349,9 +3349,9 @@ MSVehicle::processLinkApproaches(double& vSafe, double& vSafeMin, double& vSafeM
                     // could appear on a major foe link and cause a collision. Refs. #1845, #2123
                     vSafeMinDist = dpi.myDistance; // distance that must be covered
                     if (MSGlobals::gSemiImplicitEulerUpdate) {
-                        vSafeMin = MIN2((double) DIST2SPEED(vSafeMinDist + POSITION_EPS), dpi.myVLinkPass);
+                        vSafeMin = MIN3((double)DIST2SPEED(vSafeMinDist + POSITION_EPS), dpi.myVLinkPass, getCarFollowModel().maxNextSafeMin(getSpeed(), this));
                     } else {
-                        vSafeMin = MIN2((double) DIST2SPEED(2 * vSafeMinDist + NUMERICAL_EPS) - getSpeed(), dpi.myVLinkPass);
+                        vSafeMin = MIN3((double)DIST2SPEED(2 * vSafeMinDist + NUMERICAL_EPS) - getSpeed(), dpi.myVLinkPass, getCarFollowModel().maxNextSafeMin(getSpeed(), this));
                     }
                     canBrakeVSafeMin = canBrake;
 #ifdef DEBUG_EXEC_MOVE

--- a/src/microsim/cfmodels/MSCFModel.h
+++ b/src/microsim/cfmodels/MSCFModel.h
@@ -312,6 +312,16 @@ public:
     virtual double maxNextSpeed(double speed, const MSVehicle* const veh) const;
 
 
+    /** @brief Returns the maximum speed given the current speed and regarding driving dynamics
+     * @param[in] speed The vehicle's current speed
+     * @param[in] speed The vehicle itself, for obtaining other values
+     * @return The maximum possible speed for the next step taking driving dynamics into account
+     */
+    inline virtual double maxNextSafeMin(double speed, const MSVehicle* const veh = 0) const {
+        return maxNextSpeed(speed, veh);
+    }
+
+
     /** @brief Returns the minimum speed given the current speed
      * (depends on the numerical update scheme and its step width)
      * Note that it wouldn't have to depend on the numerical update

--- a/src/microsim/cfmodels/MSCFModel_EIDM.h
+++ b/src/microsim/cfmodels/MSCFModel_EIDM.h
@@ -192,6 +192,15 @@ public:
         }
     }
 
+    /** @brief Returns the maximum speed given the current speed and regarding driving dynamics
+     * @param[in] speed The vehicle's current speed
+     * @param[in] speed The vehicle itself, for obtaining other values
+     * @return The maximum possible speed for the next step taking driving dynamics into account
+     */
+    double maxNextSafeMin(double speed, const MSVehicle* const veh = 0) const {
+        return 0;
+    }
+
     /** @brief Returns the maximum velocity the CF-model wants to achieve in the next step
      * @param[in] maxSpeed The maximum achievable speed in the next step
      * @param[in] maxSpeedLane The maximum speed the vehicle wants to drive on this lane (Speedlimit*SpeedFactor)

--- a/tests/sumo/cf_model/EIDM/ticket11165/tripinfos.sumo
+++ b/tests/sumo/cf_model/EIDM/ticket11165/tripinfos.sumo
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on 2022-08-29 10:40:11 by Eclipse SUMO sumo Version v1_14_1+0352-ca30400a73b
+<!-- generated on 2022-08-31 12:35:17 by Eclipse SUMO sumo Version v1_14_1+0650-a3b0f4bd054
 This data file and the accompanying materials
 are made available under the terms of the Eclipse Public License v2.0
 which accompanies this distribution, and is available at
@@ -44,5 +44,5 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
 -->
 
 <tripinfos xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://sumo.dlr.de/xsd/tripinfo_file.xsd">
-    <tripinfo id="0" depart="0.00" departLane="SC_0" departPos="5.10" departSpeed="13.89" departDelay="0.00" arrival="1311.40" arrivalLane="CS_0" arrivalPos="89.60" arrivalSpeed="7.18" duration="1311.40" routeLength="4347.55" waitingTime="408.10" waitingCount="11" stopTime="0.00" timeLoss="998.40" rerouteNo="0" devices="tripinfo_0" vType="default" speedFactor="1.00" vaporized=""/>
+    <tripinfo id="0" depart="0.00" departLane="SC_0" departPos="5.10" departSpeed="13.89" departDelay="0.00" arrival="1351.50" arrivalLane="CS_0" arrivalPos="89.60" arrivalSpeed="7.29" duration="1351.50" routeLength="4347.55" waitingTime="442.70" waitingCount="13" stopTime="0.00" timeLoss="1038.50" rerouteNo="0" devices="tripinfo_0" vType="default" speedFactor="1.00" vaporized=""/>
 </tripinfos>


### PR DESCRIPTION
Solves issue #11225

When a EIDM-vehicle passes a minor link, it now correctly uses SlowToStartTerm and myJerkmax. The vehicle can dawdle and accelerate slowly, which was previously not allowed/possible.
This is done by ignoring vSafeMin (vehicle is not forced to drive with at least vSafeMin).

@namdre Please check, if this changed the behavior of the other models (should not have).