### PR TITLE
Fixed netedit reroute parsing bug

### DIFF
--- a/src/utils/handlers/AdditionalHandler.cpp
+++ b/src/utils/handlers/AdditionalHandler.cpp
@@ -1358,8 +1358,8 @@ AdditionalHandler::parseClosingLaneRerouteAttributes(const SUMOSAXAttributes& at
     // needed attributes
     const std::string laneID = attrs.get<std::string>(SUMO_ATTR_ID, "", parsedOk);
     // optional attributes
-    const std::string allow = attrs.getOpt<std::string>(SUMO_ATTR_ALLOW, "", parsedOk, "authority");
     const std::string disallow = attrs.getOpt<std::string>(SUMO_ATTR_DISALLOW, "", parsedOk, "");
+    const std::string allow = attrs.getOpt<std::string>(SUMO_ATTR_ALLOW, "", parsedOk, !disallow.size() ? "authority" : "");
     // check parent
     checkParent(SUMO_TAG_CLOSING_LANE_REROUTE, {SUMO_TAG_INTERVAL}, parsedOk);
     // continue if flag is ok
@@ -1381,8 +1381,8 @@ AdditionalHandler::parseClosingRerouteAttributes(const SUMOSAXAttributes& attrs)
     // needed attributes
     const std::string edgeID = attrs.get<std::string>(SUMO_ATTR_ID, "", parsedOk);
     // optional attributes
-    const std::string allow = attrs.getOpt<std::string>(SUMO_ATTR_ALLOW, "", parsedOk, "authority");
     const std::string disallow = attrs.getOpt<std::string>(SUMO_ATTR_DISALLOW, "", parsedOk, "");
+    const std::string allow = attrs.getOpt<std::string>(SUMO_ATTR_ALLOW, "", parsedOk, !disallow.size() ? "authority" : "");
     // check parent
     checkParent(SUMO_TAG_CLOSING_REROUTE, {SUMO_TAG_INTERVAL}, parsedOk);
     // continue if flag is ok


### PR DESCRIPTION
When opening an additionals file, containing a closingreroute with only the dissallowed tag, in netedit, the warning `SVCPermissions must be specified either via 'allow' or 'disallow'. Ignoring 'disallow'` is displayed and the default allow `authority` is used for the specific reroute.
This happens because `AdditionalHandler::parseClosingLaneRerouteAttributes` and `AdditionalHandler::parseClosingRerouteAttributes` always default allow to `authority `if not specified, even when `disallow `is specified by the user.