### PR TITLE
Additional CACC Wiki descriptions

### DIFF
--- a/docs/web/docs/Car-Following-Models/ACC.md
+++ b/docs/web/docs/Car-Following-Models/ACC.md
@@ -61,7 +61,7 @@ To investigate stablity effects of vehicle platoons deploying the original ACC m
 | iv | collisionAvoidanceGainSpeed | 0.07 |
 | iv | collisionAvoidanceGainSpace | 0.23 |
 
-Note, that the parameter `collisionAvoidanceOverride` (default: 2) affects the mode (iv) by overriding the followSpeed when deemed unsafe by the given margin. To eliminate this case, which slightly affects the platooning behaviour, but not the string instability itself, you this parameter may be set to to a much larger value (i.e. 100) to avoid the effect.
+Note, that the parameter `collisionAvoidanceOverride` (default: 2) affects the mode (iv) by overriding the followSpeed when deemed unsafe by the given margin. To eliminate this case, which slightly affects the platooning behaviour, but not the string instability itself, this parameter may be set to to a much larger value (i.e. 100) to avoid the effect.
 
 The default parameters of the ACC model can be found here: [Car-Following Model Parameters](../Definition_of_Vehicles,_Vehicle_Types,_and_Routes.md#car-following_model_parameters)
 

--- a/docs/web/docs/Car-Following-Models/CACC.md
+++ b/docs/web/docs/Car-Following-Models/CACC.md
@@ -2,33 +2,35 @@
 title: CACC
 ---
 
-## Overview
+# Overview
 
 The integrated CACC car-following model is based on the work of Milanés
 & Shladover [\[1\]](#references), Xiao, Wang & van Arem [\[2\]](#references) and Xiao, Wang, Schakel &
 van Arem [\[3\]](#references), wherein the developed control law in the ACC control
 algorithm is explicitly divided into three modes: (i) speed (or
-cruising) control, (ii) gap-closing control and (iii) gap control. A
+cruising) control, (ii) gap control and (iii) gap-closing control. A
 fourth mode (i.e. collision avoidance mode) has been introduced within
 the project [TransAID](https://www.transaid.eu).
 
 see also [ACC model](ACC.md).
 
-## Speed control mode
+## (i) Speed control mode
 
 The speed control mode is designed to maintain the pre-defined by the
 driver desired speed and is activated when there are no preceding
 vehicles in the range covered by the sensors or when the time-gap is
 larger than 2 s.
 
-## Gap control mode
+Additionally, to ensure a smooth acceleration profile when closing in on a stopped vehicle, the `speedControlMinGap` is also evaluated to activate the speed control mode. (We found a default of 1.66m to be feasible.)
+
+## (ii) Gap control mode
 
 The gap control mode aims to maintain a constant time gap between the
 CACC-equipped vehicle and its predecessor and is activated when the gap
 and speed deviations (with respect to the preceding vehicle) are
 concurrently smaller than 0.2 m and 0.1 m/s, respectively.
 
-## Gap-closing control mode
+## (iii) Gap-closing control mode
 
 The gap-closing controller enables the smooth transition from speed
 control mode to gap control mode and is triggered when the time-gap is
@@ -37,27 +39,27 @@ CACC-equipped vehicle retains the previous control strategy to provide
 hysteresis in the control loop and perform a smooth transfer between the
 two strategies.
 
-## Collision avoidance control mode
+## (iv) Collision avoidance control mode
 
 The collision avoidance mode prevents rear-end collisions when safety
 critical conditions prevail. This mode is activated when the time-gap is
 less than 1.5 s and the gap deviation is negative.
 
-Also, If the followSpeed computed by the CACC model grows higher than the safe followSpeed as computed by the default Krauss model by a given margin (configured by collisionAvoidanceOverride), the speed is limited to the value of Krauss-speed + margin. The override margin defaults to 2m/s.
+Also, If the `followSpeed` computed by the CACC model grows higher than the safe `followSpeed` as computed by the default Krauss model by a given margin (configured by `collisionAvoidanceOverride`), the speed is limited to the value of Krauss-speed + margin. The override margin defaults to 2m/s.
 
-## Notes
+# Notes
 
 - The implemented model can be found in [{{SUMO}}/src/microsim/cfmodels/MSCFModel_CACC.cpp]({{Source}}src/microsim/cfmodels/MSCFModel_CACC.cpp).
 - This part of SUMO was developed and extended within the project
   [TransAID](https://www.transaid.eu).
 - The model is primarily intended for use in specific traffic
-  situations.  
+  situations.
 - When there is no leader vehicle, the model uses the same speed as the Krauss model to approach junctions and speed limits
   
 !!! caution
     The model is known to produce collisions at the default step-length of 1s. Better results can be achieved by setting a lower step length.
 
-## References
+# References
 
 1.  Milanés, V., & Shladover, S. E. (2014). Modeling cooperative and
     autonomous adaptive cruise control dynamic responses using


### PR DESCRIPTION
In reference to #11679, a few edits to the CACC wiki. 
(Also found a typo in the ACC wiki.)