### PR TITLE
Additional route file support for cycle adaption script

### DIFF
--- a/tools/tlsCycleAdaptation.py
+++ b/tools/tlsCycleAdaptation.py
@@ -31,11 +31,8 @@
  the optimal cycle length will be set to 120 sec.
 """
 
-# from __future__ import absolute_import
-# from __future__ import print_function
-import logging
-logging.basicConfig()
-logger = logging.getLogger(__name__)
+from __future__ import absolute_import
+from __future__ import print_function
 
 import collections
 
@@ -85,20 +82,18 @@ def get_options(args=None):
     return optParser.parse_args(args=args)
 
 
-
 def getEdges(veh, net, routes):
     if isinstance(veh.route, str):
-        logger.debug(f'working with: {veh.route}')       
         edges = routes[veh.route]
     else:
         edges = veh.route[0].edges
     return [net.getEdge(e) for e in edges.split()]
 
+
 def getRoutes(files):
     route_dict = {}
     for file in files:
         for route in sumolib.output.parse(file, 'route'):
-            logger.debug(route)
             route_dict[route.id] = route.edges
     return route_dict
 
@@ -122,7 +117,6 @@ def getFlows(net, routeFiles, tlsList, begin, verbose, isSorted=False):
                     break
                 continue
             if sumolib.miscutils.parseTime(veh.depart) >= begin:
-                logger.debug(f'vehicles: {veh}')
                 edgeList = getEdges(veh, net, route_dict)
                 for idx, edge in enumerate(edgeList):
                     tls = None if edge.getToNode().getType() in ("rail_crossing", "rail_signal") else edge.getTLS()
@@ -466,8 +460,4 @@ def main(options):
 
 if __name__ == "__main__":
     options = get_options()
-    if options.verbose:
-        logger.setLevel('DEBUG')
-    else:
-        logger.setLevel('INFO')
     main(options)


### PR DESCRIPTION
Currently the `tools/tlsCycleAdaption.py` script only supports `route.rou.xml` files that look like:

```XML
<routes>
    <vType id="type1" accel="0.8" decel="4.5" sigma="0.5" length="5" maxSpeed="70"/>
    <vehicle id="0" type="type1" depart="0" color="1,0,0">
      <route edges="beg middle end rend"/>
    </vehicle>
</routes>
```

However there is the option to specify routes and trips like this as well:

```XML
<routes>
    <vType id="type1" accel="0.8" decel="4.5" sigma="0.5" length="5" maxSpeed="70"/>

    <route id="route0" color="1,1,0" edges="beg middle end rend"/>

    <vehicle id="0" type="type1" route="route0" depart="0" color="1,0,0"/>
    <vehicle id="1" type="type1" route="route0" depart="0" color="0,1,0"/>

</routes>
```

This PR add support for the second type of trips XML file. 