### PR TITLE
Turning angles with continuous lane changes and lcSigma

### DIFF
--- a/src/microsim/MSLaneChanger.cpp
+++ b/src/microsim/MSLaneChanger.cpp
@@ -490,6 +490,7 @@ MSLaneChanger::continueChange(MSVehicle* vehicle, ChangerIt& from) {
     }
     if (!lcm.isChangingLanes()) {
         vehicle->myState.myPosLat = 0;
+        lcm.setSpeedLat(0.0);
         lcm.endLaneChangeManeuver();
     }
     lcm.updateShadowLane();

--- a/src/microsim/MSLaneChanger.cpp
+++ b/src/microsim/MSLaneChanger.cpp
@@ -292,8 +292,9 @@ MSLaneChanger::change() {
 
     if (vehicle->getLaneChangeModel().isChangingLanes() && !vehicle->getLaneChangeModel().alreadyChanged()) {
         return continueChange(vehicle, myCandi);
+    } else if (!(vehicle->getLaneChangeModel().getSigmaLat() > 0)) {
+        vehicle->getLaneChangeModel().setSpeedLat(0);
     }
-    vehicle->getLaneChangeModel().setSpeedLat(0);
     if (!myAllowsChanging || vehicle->getLaneChangeModel().alreadyChanged() || vehicle->isStoppedOnLane()) {
         registerUnchanged(vehicle);
         if (vehicle->isStoppedOnLane()) {

--- a/src/microsim/MSLaneChangerSublane.cpp
+++ b/src/microsim/MSLaneChangerSublane.cpp
@@ -473,6 +473,11 @@ MSLaneChangerSublane::startChangeSublane(MSVehicle* vehicle, ChangerIt& from, do
     const double posLat = -vehicle->myState.myPosLat; // @todo get rid of the '-'
     const double lefthandSign = (MSGlobals::gLefthand ? -1 : 1);
     Position p1 = vehicle->getLane()->geometryPositionAtOffset(vehicle->myState.myPos, lefthandSign * posLat);
+    if (p1 == Position::INVALID && vehicle->getLane()->getShape().length2D() == 0. && vehicle->getLane()->isInternal()) {
+        // workaround: extrapolate the preceding lane shape
+        MSLane* predecessorLane = vehicle->getLane()->getCanonicalPredecessorLane();
+        p1 = predecessorLane->geometryPositionAtOffset(predecessorLane->getLength() + vehicle->myState.myPos, lefthandSign * posLat);
+    }
     Position p2 = vehicle->getBackPosition();
     if (p2 == Position::INVALID) {
         // Handle special case of vehicle's back reaching out of the network

--- a/src/microsim/MSVehicle.cpp
+++ b/src/microsim/MSVehicle.cpp
@@ -4308,6 +4308,7 @@ MSVehicle::executeMove() {
             }
 #endif
         }
+        myLaneChangeModel->setPreviousAngleOffset(myLaneChangeModel->getAngleOffset());
         myAngle = computeAngle();
     }
 

--- a/src/microsim/MSVehicle.cpp
+++ b/src/microsim/MSVehicle.cpp
@@ -1425,9 +1425,9 @@ MSVehicle::computeAngle() const {
     }
     double result = (p1 != p2 ? p2.angleTo2D(p1) :
                      myLane->getShape().rotationAtOffset(myLane->interpolateLanePosToGeometryPos(getPositionOnLane())));
-    if (myLaneChangeModel->isChangingLanes()) {
-        result += lefthandSign * DEG2RAD(myLaneChangeModel->getAngleOffset());
-    }
+
+    result += lefthandSign * myLaneChangeModel->calcAngleOffset();
+
 #ifdef DEBUG_FURTHER
     if (DEBUG_COND) {
         std::cout << SIMTIME << " computeAngle veh=" << getID() << " p1=" << p1 << " p2=" << p2 << " angle=" << RAD2DEG(result) << " naviDegree=" << GeomHelper::naviDegree(result) << "\n";

--- a/src/microsim/lcmodels/MSAbstractLaneChangeModel.cpp
+++ b/src/microsim/lcmodels/MSAbstractLaneChangeModel.cpp
@@ -108,6 +108,7 @@ MSAbstractLaneChangeModel::MSAbstractLaneChangeModel(MSVehicle& v, const LaneCha
     mySpeedLat(0),
     myAccelerationLat(0),
     myAngleOffset(0),
+    myPreviousAngleOffset(0),
     myCommittedSpeed(0),
     myLaneChangeCompletion(1.0),
     myLaneChangeDirection(0),
@@ -726,11 +727,11 @@ MSAbstractLaneChangeModel::determineTargetLane(int& targetDir) const {
 double
 MSAbstractLaneChangeModel::calcAngleOffset() {
     double result = 0.;
-    if (!(fabs(mySpeedLat) < NUMERICAL_EPS && fabs(myAngleOffset * 180 / PI) < NUMERICAL_EPS)) {
+    if (!(fabs(mySpeedLat) < NUMERICAL_EPS && fabs(myPreviousAngleOffset * 180 / PI) < NUMERICAL_EPS)) {
         if (myVehicle.getLength() < sqrt(SPEED2DIST(mySpeedLat) * SPEED2DIST(mySpeedLat) + SPEED2DIST(myVehicle.getSpeed()) * SPEED2DIST(myVehicle.getSpeed()))) {
             result = atan2(mySpeedLat, myVehicle.getSpeed());
         } else {
-            result = myAngleOffset + asin((sin(PI / 2 - myAngleOffset) * (SPEED2DIST(mySpeedLat) - tan(myAngleOffset)*SPEED2DIST(myVehicle.getSpeed()))) / myVehicle.getLength());
+            result = myPreviousAngleOffset + asin((sin(PI / 2 - myPreviousAngleOffset) * (SPEED2DIST(mySpeedLat) - tan(myPreviousAngleOffset) * SPEED2DIST(myVehicle.getSpeed()))) / myVehicle.getLength());
         }
     }
 

--- a/src/microsim/lcmodels/MSAbstractLaneChangeModel.h
+++ b/src/microsim/lcmodels/MSAbstractLaneChangeModel.h
@@ -468,7 +468,12 @@ public:
     int getShadowDirection() const;
 
     /// @brief return the angle offset during a continuous change maneuver
-    double getAngleOffset() const;
+    double calcAngleOffset();
+
+    /// @brief set the angle offset resulting from lane change and sigma
+    double getAngleOffset() const {
+        return myAngleOffset;
+    }
 
     /// @brief reset the flag whether a vehicle already moved to false
     inline bool alreadyChanged() const {
@@ -565,6 +570,11 @@ public:
         return myAccelerationLat;
     }
 
+    /// @brief return the factor for lane keeping imperfection
+    double getSigmaLat() const {
+        return mySigma;
+    }
+
     /// @brief set the lateral speed and update lateral acceleraton
     void setSpeedLat(double speedLat);
 
@@ -649,6 +659,9 @@ protected:
 
     /// @brief the current lateral acceleration
     double myAccelerationLat;
+
+    /// @brief the current angle offset resulting from lane change and sigma
+    double myAngleOffset;
 
     /// @brief the speed when committing to a change maneuver
     double myCommittedSpeed;

--- a/src/microsim/lcmodels/MSAbstractLaneChangeModel.h
+++ b/src/microsim/lcmodels/MSAbstractLaneChangeModel.h
@@ -470,9 +470,19 @@ public:
     /// @brief return the angle offset during a continuous change maneuver
     double calcAngleOffset();
 
-    /// @brief set the angle offset resulting from lane change and sigma
-    double getAngleOffset() const {
+    /// @brief return the angle offset resulting from lane change and sigma
+    inline double getAngleOffset() const {
         return myAngleOffset;
+    }
+
+    /// @brief set the angle offset resulting from lane change and sigma
+    inline void setAngleOffset(const double angleOffset) {
+        myAngleOffset = angleOffset;
+    }
+
+    /// @brief set the angle offset of the previous time step
+    inline void setPreviousAngleOffset(const double angleOffset) {
+        myPreviousAngleOffset = angleOffset;
     }
 
     /// @brief reset the flag whether a vehicle already moved to false
@@ -662,6 +672,9 @@ protected:
 
     /// @brief the current angle offset resulting from lane change and sigma
     double myAngleOffset;
+
+    /// @brief the angle offset of the previous time step resulting from lane change and sigma
+    double myPreviousAngleOffset;
 
     /// @brief the speed when committing to a change maneuver
     double myCommittedSpeed;

--- a/src/microsim/lcmodels/MSLCM_LC2013.cpp
+++ b/src/microsim/lcmodels/MSLCM_LC2013.cpp
@@ -1076,6 +1076,7 @@ MSLCM_LC2013::prepareStep() {
             scaledDelta = deltaPosLat * myVehicle.getSpeed() / myVehicle.getLane()->getSpeedLimit();
         }
         myVehicle.setLateralPositionOnLane(oldPosLat + scaledDelta);
+        myVehicle.getLaneChangeModel().setSpeedLat(DIST2SPEED(scaledDelta));
     }
 }
 
@@ -1984,7 +1985,7 @@ MSLCM_LC2013::slowDownForBlocked(MSVehicle** blocked, int state) {
                 }
 #endif
             } /* else {
-            	// experimental else-branch...
+                // experimental else-branch...
                 state |= LCA_AMBACKBLOCKER;
                 myVSafes.push_back(getCarFollowModel().followSpeed(
                                        &myVehicle, myVehicle.getSpeed(),


### PR DESCRIPTION
This pull request belongs to #8529.

The "new" Code part is the geometric calculation in calcAngleOffset and works as described in the last image.
As it uses speedLat, I needed to make sure that it always gets calculated.

I did not want to update all the tests that now change because of the fcd-output, so please do some tests before integrating. 