### PR TITLE
docs: Instructions for Dockerfile.fedora

### DIFF
--- a/build/docker/Dockerfile.fedora
+++ b/build/docker/Dockerfile.fedora
@@ -1,3 +1,10 @@
+# to build this image run the following command
+# $ docker build -t sumo - < Dockerfile.fedora
+# to use it run (GUI applications won't work)
+# $ docker run -it sumo bash
+# now you have a bash inside a docker container and can for instance run
+# $ cd sumo; bin/sumo -c docs/examples/sumo/busses/test.sumocfg
+
 FROM fedora:rawhide
 
 RUN dnf -y upgrade

--- a/build/docker/Dockerfile.fedora
+++ b/build/docker/Dockerfile.fedora
@@ -1,7 +1,7 @@
 # to build this image run the following command
-# $ docker build -t sumo - < Dockerfile.fedora
+# $ docker build -t sumo:fedorarawhide - < Dockerfile.fedora
 # to use it run (GUI applications won't work)
-# $ docker run -it sumo bash
+# $ docker run -it sumo:fedorarawhide bash
 # now you have a bash inside a docker container and can for instance run
 # $ cd sumo; bin/sumo -c docs/examples/sumo/busses/test.sumocfg
 


### PR DESCRIPTION
In this PR, the following functionality has been added:
- Build and run instructions for `Dockerfile.fedora`

The format of these instructions conform to those present in the other Dockerfiles.