### PR TITLE
more helpful error background images message

### DIFF
--- a/tools/osmWebWizard.py
+++ b/tools/osmWebWizard.py
@@ -293,10 +293,10 @@ class Builder(object):
                 tileGet.get(tileOptions)
                 self.report("Success.")
                 self.decalError = False
-            except Exception:
+            except Exception as e:
                 os.chdir(self.tmp)
                 shutil.rmtree("background_images", ignore_errors=True)
-                self.report("Error while downloading background images")
+                self.report("Error while downloading background images: %s" % e)
                 self.decalError = True
 
         if self.data["vehicles"] or ptOptions:


### PR DESCRIPTION
osmWebwizard throws an exception when the `satellite background` option is checked. 
The exception looks like:
```
Downloading background images
Error while downloading background images
```
But doesn't elaborate on what went wrong.

This PR throws the exception along with the error message, like:
```
Downloading background images
Error while downloading background images: No module named pyproj
```

In my case the Python module `pyproj` was missing and I had to manually install it. Perhaps this can be part of a requirements file before running osmWebwizard?