### PR TITLE
bug fix unified cycle doens't have the exact same cycle length

### DIFF
--- a/tools/tlsCycleAdaptation.py
+++ b/tools/tlsCycleAdaptation.py
@@ -369,19 +369,27 @@ def optimizeGreenTime(tl, groupFlowsMap, phaseLaneIndexMap, currentLength, optio
 
     # adjust the green times if minimal green times are applied for keeping the defined maximal cycle length.
     if minGreenPhasesList and totalLength > options.maxcycle and options.restrict:
+        totalLength = lostTime
         if options.verbose:
             print("Re-allocate the green splits!")
         adjustGreenTimes = totalGreenTimes - len(minGreenPhasesList) * options.mingreen
         for i in groupFlowsMap:
             if i not in minGreenPhasesList:
-                groupFlowsMap[i][0] = int((groupFlowsMap[i][0] / float(subtotalGreenTimes)) * adjustGreenTimes)
+                groupFlowsMap[i][0] = int(round((groupFlowsMap[i][0] / float(subtotalGreenTimes)) * adjustGreenTimes))
+            totalLength += groupFlowsMap[i][0]
+
+    if options.unicycle and totalLength != optCycle:
+        diff = optCycle - totalLength
+        secs_to_distribute = [diff / abs(diff)] * abs(diff)
+        for i, s in enumerate(secs_to_distribute):
+            groupFlowsMap[groupFlowsMap.keys()[i % len(groupFlowsMap)]][0] += s
 
     if options.verbose:
         totalLength = lostTime
         for i in groupFlowsMap:
             totalLength += groupFlowsMap[i][0]
             print("Green time for phase %s: %s" % (i, groupFlowsMap[i][0]))
-        print("the optimal cycle length:%s" % totalLength)
+        print("the optimal cycle length:%s\n" % totalLength)
 
     return groupFlowsMap
 


### PR DESCRIPTION
When the `unicycle` option is enabled when using the `tools/tlsCycleAdaptation.py` script, the cycle times of different traffic lights are not always the same. This bug occurs when the `phase durations` of a traffic light are rounded, the total cycle time can increase or decrease by a few seconds.

A simple example: If the total cycle time is `100` seconds and there are three phases with equal phase lengths, the resultant phase durations will be `33.33` seconds for each phase. If we round this to `33` seconds for each phase, we lose one second from the total cycle time (which is now `99` seconds). This will cause some drift among traffic lights because some will have a `99` second cycle time and others will have a `100` second cycle time, and so on.

This error occurs in two places in the `tools/tlsCycleAdaptation.py` script where rounding is used.

This PR corrects the error by distributing the remaining seconds among the traffic light phases. This is still a work in progress because there are numerous ways to fix this bug.