### PR TITLE
Exporting crosswalk objects to OpenDrive

### DIFF
--- a/src/netwrite/NWWriter_OpenDrive.cpp
+++ b/src/netwrite/NWWriter_OpenDrive.cpp
@@ -122,20 +122,20 @@ NWWriter_OpenDrive::writeNetwork(const OptionsCont& oc, NBNetBuilder& nb) {
 
     mapmatchRoadObjects(nb.getShapeCont(), ec);
 
-    PositionVector crossing_shape;
-    std::map<std::string, std::vector<std::string>> crossingsByEdgeId;
+    PositionVector crosswalk_shape;
+    std::map<std::string, std::vector<std::string>> crosswalksByEdge;
     for (auto it = nc.begin(); it != nc.end(); ++it) {
         NBNode* n = it->second;
-        auto crossings = n->getCrossings();
-        if (crossings.size() > 0)
+        auto crosswalks = n->getCrossings();
+        for (size_t i = 0; i < crosswalks.size(); i++)
         {
-            crossing_shape = crossings[0]->shape;
-            auto newvector1 = crossing_shape.getOrthogonal(crossing_shape[0], false, false, 4.0, -90);
-            auto newvector2 = crossing_shape.getOrthogonal(crossing_shape[1], false, true, 4.0, 90);
-            crossing_shape.push_back(newvector2[1]);
-            crossing_shape.push_back(newvector1[1]);
-            nb.getShapeCont().addPolygon(crossings[0]->id, "crossing", RGBColor::BLACK, 0, Shape::DEFAULT_ANGLE, Shape::DEFAULT_IMG_FILE, Shape::DEFAULT_RELATIVEPATH, crossing_shape, false, true, 1, true, crossings[0]->edges[0]->getID());
-            crossingsByEdgeId[crossings[0]->edges[0]->getID()].push_back(crossings[0]->id);
+            crosswalk_shape = crosswalks[i]->shape;
+            auto newvector1 = crosswalk_shape.getOrthogonal(crosswalk_shape[0], false, false, 4.0, -90);
+            auto newvector2 = crosswalk_shape.getOrthogonal(crosswalk_shape[1], false, true, 4.0, 90);
+            crosswalk_shape.push_back(newvector2[1]);
+            crosswalk_shape.push_back(newvector1[1]);
+            nb.getShapeCont().addPolygon(crosswalks[i]->id, "crosswalk", RGBColor::BLACK, 0, Shape::DEFAULT_ANGLE, Shape::DEFAULT_IMG_FILE, Shape::DEFAULT_RELATIVEPATH, crosswalk_shape, false, true, 1, true, crosswalks[i]->edges[0]->getID());
+            crosswalksByEdge[crosswalks[i]->edges[0]->getID()].push_back(crosswalks[i]->id);
         }
     }
 
@@ -150,7 +150,7 @@ NWWriter_OpenDrive::writeNetwork(const OptionsCont& oc, NBNetBuilder& nb) {
                         origNames, straightThresh,
                         nb.getShapeCont(),
                         signalLanes,
-                        crossingsByEdgeId[e->getID()]);
+                        crosswalksByEdge[e->getID()]);
     }
     device.lf();
 

--- a/src/netwrite/NWWriter_OpenDrive.h
+++ b/src/netwrite/NWWriter_OpenDrive.h
@@ -69,7 +69,8 @@ protected:
                                 const bool origNames,
                                 const double straightThresh,
                                 const ShapeContainer& shc,
-                                SignalLanes& signalLanes, const std::vector<std::string>& crossings);
+                                SignalLanes& signalLanes,
+                                const std::vector<std::string>& crossings);
 
     /// @brief write internal edge to device, return next connectionID
     static int writeInternalEdge(OutputDevice& device, OutputDevice& junctionDevice,

--- a/src/netwrite/NWWriter_OpenDrive.h
+++ b/src/netwrite/NWWriter_OpenDrive.h
@@ -69,7 +69,7 @@ protected:
                                 const bool origNames,
                                 const double straightThresh,
                                 const ShapeContainer& shc,
-                                SignalLanes& signalLanes);
+                                SignalLanes& signalLanes, const std::vector<std::string>& crossings);
 
     /// @brief write internal edge to device, return next connectionID
     static int writeInternalEdge(OutputDevice& device, OutputDevice& junctionDevice,
@@ -117,7 +117,7 @@ protected:
     static void checkLaneGeometries(const NBEdge* e);
 
     /// @brief write road objects referenced as edge parameters
-    static void writeRoadObjects(OutputDevice& device, const NBEdge* e, const ShapeContainer& shc);
+    static void writeRoadObjects(OutputDevice& device, const NBEdge* e, const ShapeContainer& shc, const std::vector<std::string>& crossings);
 
     /// @brief write signal record for traffic light
     static void writeSignals(OutputDevice& device, const NBEdge* e, double length, SignalLanes& signalLanes, const ShapeContainer& shc);

--- a/tests/netconvert/export/openDRIVE/lefthand_sidewalk/foreign.netconvert
+++ b/tests/netconvert/export/openDRIVE/lefthand_sidewalk/foreign.netconvert
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on 2022-11-19 16:29:33 by Eclipse SUMO netconvert Version v1_15_0+0442-fb08314
+<!-- generated on 2022-12-05 09:27:55 by Eclipse SUMO netconvert Version v1_15_0+0690-246ca29486b
 This data file and the accompanying materials
 are made available under the terms of the Eclipse Public License v2.0
 which accompanies this distribution, and is available at
@@ -48,7 +48,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
 -->
 
 <OpenDRIVE>
-    <header revMajor="1" revMinor="4" name="" version="1.00" date="Sat Nov 19 16:29:33 2022" north="200.00" south="0.00" east="200.00" west="0.00"/>
+    <header revMajor="1" revMinor="4" name="" version="1.00" date="Mon Dec  5 09:27:55 2022" north="200.00" south="0.00" east="200.00" west="0.00"/>
     <road name="" length="92.80000000" id="50" junction="-1">
         <link>
             <predecessor elementType="junction" elementId="1"/>
@@ -87,7 +87,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":C_c1" type="crosswalk" name="" s="0.00000000" t="-5.41202365" hdg="-0.00000000">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-0.50000000" v="3.20000000" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-0.50000000" v="-3.20000000" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="0.50000000" v="-3.20000000" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="0.50000000" v="3.20000000" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="CE"/>
     </road>
@@ -129,7 +138,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":C_c2" type="crosswalk" name="" s="0.00000000" t="-5.41202365" hdg="-1.57079633">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-3.20000000" v="-0.50000000" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="3.20000000" v="-0.50000000" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="3.20000000" v="0.50000000" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-3.20000000" v="0.50000000" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="CN"/>
     </road>
@@ -171,7 +189,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":C_c0" type="crosswalk" name="" s="0.00000000" t="-5.41202365" hdg="1.57079633">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="3.20000000" v="0.50000000" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-3.20000000" v="0.50000000" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-3.20000000" v="-0.50000000" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="3.20000000" v="-0.50000000" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="CS"/>
     </road>
@@ -213,7 +240,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":C_c3" type="crosswalk" name="" s="0.00000000" t="-5.41202365" hdg="-3.14159265">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="0.50000000" v="-3.20000000" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="0.50000000" v="3.20000000" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-0.50000000" v="3.20000000" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-0.50000000" v="-3.20000000" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="CW"/>
     </road>
@@ -453,7 +489,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-1"/>
                             <successor id="-1"/>
                         </link>
-                        <width sOffset="0" a="2.00" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="2.00" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -462,7 +498,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-2"/>
                             <successor id="-2"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -501,7 +537,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-2"/>
                             <successor id="-2"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="broken" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -540,7 +576,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-2"/>
                             <successor id="-2"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="none" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -579,7 +615,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-1"/>
                             <successor id="-1"/>
                         </link>
-                        <width sOffset="0" a="2.00" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="2.00" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -588,7 +624,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-2"/>
                             <successor id="-2"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -627,7 +663,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-2"/>
                             <successor id="-2"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="broken" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -666,7 +702,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-2"/>
                             <successor id="-2"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="none" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -705,7 +741,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-1"/>
                             <successor id="-1"/>
                         </link>
-                        <width sOffset="0" a="2.00" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="2.00" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -714,7 +750,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-2"/>
                             <successor id="-2"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -753,7 +789,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-2"/>
                             <successor id="-2"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="broken" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -792,7 +828,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-2"/>
                             <successor id="-2"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="none" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -831,7 +867,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-1"/>
                             <successor id="-1"/>
                         </link>
-                        <width sOffset="0" a="2.00" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="2.00" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -840,7 +876,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-2"/>
                             <successor id="-2"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -879,7 +915,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-2"/>
                             <successor id="-2"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="broken" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -918,7 +954,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="-2"/>
                             <successor id="-2"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="none" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>

--- a/tests/netconvert/export/openDRIVE/lefthand_sidewalk_LHLL/foreign.netconvert
+++ b/tests/netconvert/export/openDRIVE/lefthand_sidewalk_LHLL/foreign.netconvert
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on 2022-11-15 17:31:52 by Eclipse SUMO netconvert Version v1_15_0+0291-dfcc2ff
+<!-- generated on 2022-12-05 09:27:55 by Eclipse SUMO netconvert Version v1_15_0+0690-246ca29486b
 This data file and the accompanying materials
 are made available under the terms of the Eclipse Public License v2.0
 which accompanies this distribution, and is available at
@@ -21,6 +21,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
         <write-license value="true"/>
         <opendrive-output value="foreign.net"/>
         <output.original-names value="true"/>
+        <opendrive-output.lefthand-left value="true"/>
     </output>
 
     <processing>
@@ -48,7 +49,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
 -->
 
 <OpenDRIVE>
-    <header revMajor="1" revMinor="4" name="" version="1.00" date="Tue Nov 15 17:31:52 2022" north="200.00" south="0.00" east="200.00" west="0.00"/>
+    <header revMajor="1" revMinor="4" name="" version="1.00" date="Mon Dec  5 09:27:55 2022" north="200.00" south="0.00" east="200.00" west="0.00"/>
     <road name="" length="92.80000000" id="50" junction="-1">
         <link>
             <predecessor elementType="junction" elementId="1"/>
@@ -87,7 +88,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                 </center>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":C_c1" type="crosswalk" name="" s="0.00000000" t="1.50000000" hdg="-0.00000000">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-0.50000000" v="3.20000000" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-0.50000000" v="-3.20000000" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="0.50000000" v="-3.20000000" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="0.50000000" v="3.20000000" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="CE"/>
     </road>
@@ -129,7 +139,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                 </center>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":C_c2" type="crosswalk" name="" s="0.00000000" t="1.50000000" hdg="-1.57079633">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-3.20000000" v="-0.50000000" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="3.20000000" v="-0.50000000" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="3.20000000" v="0.50000000" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-3.20000000" v="0.50000000" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="CN"/>
     </road>
@@ -171,7 +190,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                 </center>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":C_c0" type="crosswalk" name="" s="0.00000000" t="1.50000000" hdg="1.57079633">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="3.20000000" v="0.50000000" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-3.20000000" v="0.50000000" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-3.20000000" v="-0.50000000" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="3.20000000" v="-0.50000000" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="CS"/>
     </road>
@@ -213,7 +241,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                 </center>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":C_c3" type="crosswalk" name="" s="0.00000000" t="1.50000000" hdg="-3.14159265">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="0.50000000" v="-3.20000000" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="0.50000000" v="3.20000000" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-0.50000000" v="3.20000000" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-0.50000000" v="-3.20000000" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="CW"/>
     </road>
@@ -453,7 +490,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="2"/>
                             <successor id="2"/>
                         </link>
-                        <width sOffset="0" a="2.00" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="2.00" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -462,7 +499,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="1"/>
                             <successor id="1"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -501,7 +538,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="1"/>
                             <successor id="1"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="broken" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -540,7 +577,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="1"/>
                             <successor id="1"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="none" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -579,7 +616,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="2"/>
                             <successor id="2"/>
                         </link>
-                        <width sOffset="0" a="2.00" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="2.00" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -588,7 +625,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="1"/>
                             <successor id="1"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -627,7 +664,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="1"/>
                             <successor id="1"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="broken" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -666,7 +703,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="1"/>
                             <successor id="1"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="none" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -705,7 +742,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="2"/>
                             <successor id="2"/>
                         </link>
-                        <width sOffset="0" a="2.00" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="2.00" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -714,7 +751,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="1"/>
                             <successor id="1"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -753,7 +790,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="1"/>
                             <successor id="1"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="broken" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -792,7 +829,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="1"/>
                             <successor id="1"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="none" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -831,7 +868,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="2"/>
                             <successor id="2"/>
                         </link>
-                        <width sOffset="0" a="2.00" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="2.00" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -840,7 +877,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="1"/>
                             <successor id="1"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="solid" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -879,7 +916,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="1"/>
                             <successor id="1"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="broken" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>
@@ -918,7 +955,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                             <predecessor id="1"/>
                             <successor id="1"/>
                         </link>
-                        <width sOffset="0" a="3.20" b="0" c="0" d="0"/>
+                        <width sOffset="0" a="3.20" b="0.00" c="0.00" d="0.00"/>
                         <roadMark sOffset="0" type="none" weight="standard" color="standard" width="0.13"/>
                         <speed sOffset="0" max="13.89"/>
                     </lane>

--- a/tests/netconvert/export/openDRIVE/multimodal/foreign.netconvert
+++ b/tests/netconvert/export/openDRIVE/multimodal/foreign.netconvert
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on 2022-11-25 16:12:53 by Eclipse SUMO netconvert Version v1_15_0+0602-b38f846bfb8
+<!-- generated on 2022-12-05 09:27:55 by Eclipse SUMO netconvert Version v1_15_0+0690-246ca29486b
 This data file and the accompanying materials
 are made available under the terms of the Eclipse Public License v2.0
 which accompanies this distribution, and is available at
@@ -48,7 +48,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
 -->
 
 <OpenDRIVE>
-    <header revMajor="1" revMinor="4" name="" version="1.00" date="Fri Nov 25 16:12:53 2022" north="200.00" south="0.00" east="200.00" west="0.00"/>
+    <header revMajor="1" revMinor="4" name="" version="1.00" date="Mon Dec  5 09:27:55 2022" north="200.00" south="0.00" east="200.00" west="0.00"/>
     <road name="" length="86.60000000" id="50" junction="-1">
         <link>
             <predecessor elementType="junction" elementId="1"/>
@@ -106,7 +106,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":C_c1" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="-0.00000000">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="0.50000000" v="-7.40000000" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="0.50000000" v="7.40000000" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-0.50000000" v="7.40000000" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-0.50000000" v="-7.40000000" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="CE"/>
     </road>
@@ -167,7 +176,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":C_c0" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="-1.57079633">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="7.40000000" v="0.50000000" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-7.40000000" v="0.50000000" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-7.40000000" v="-0.50000000" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="7.40000000" v="-0.50000000" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="CN"/>
     </road>
@@ -228,7 +246,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":C_c2" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="1.57079633">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-7.40000000" v="-0.50000000" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="7.40000000" v="-0.50000000" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="7.40000000" v="0.50000000" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-7.40000000" v="0.50000000" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="CS"/>
     </road>
@@ -289,7 +316,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":C_c3" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="-3.14159265">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-0.50000000" v="7.40000000" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-0.50000000" v="-7.40000000" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="0.50000000" v="-7.40000000" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="0.50000000" v="7.40000000" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="CW"/>
     </road>

--- a/tests/netconvert/export/openDRIVE/roadObjects/foreign.netconvert
+++ b/tests/netconvert/export/openDRIVE/roadObjects/foreign.netconvert
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- generated on 2022-11-25 16:12:54 by Eclipse SUMO netconvert Version v1_15_0+0602-b38f846bfb8
+<!-- generated on 2022-12-05 09:27:58 by Eclipse SUMO netconvert Version v1_15_0+0690-246ca29486b
 This data file and the accompanying materials
 are made available under the terms of the Eclipse Public License v2.0
 which accompanies this distribution, and is available at
@@ -51,7 +51,7 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
 -->
 
 <OpenDRIVE>
-    <header revMajor="1" revMinor="4" name="" version="1.00" date="Fri Nov 25 16:12:54 2022" north="2335.16" south="1844.07" east="2701.86" west="2090.59">
+    <header revMajor="1" revMinor="4" name="" version="1.00" date="Mon Dec  5 09:27:58 2022" north="2335.16" south="1844.07" east="2701.86" west="2090.59">
         <geoReference>
  <![CDATA[
  +proj=utm +zone=33 +ellps=WGS84 +datum=WGS84 +units=m +no_defs
@@ -110,7 +110,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":cluster_21487209_3831343134_c2" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="2.55084808">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-2.19759883" v="2.37919427" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="1.36707278" v="-2.93617405" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="2.19759883" v="-2.37919427" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-1.36707278" v="2.93617405" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="-136571494#7"/>
     </road>
@@ -505,7 +514,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":29219440_c2" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="2.54402382">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-2.21378264" v="2.36414180" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="1.38707672" v="-2.92677607" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="2.21378264" v="-2.36414180" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-1.38707672" v="2.92677607" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals>
             <signal id="joinedS_2480337678_4566145597_cluster_21487209_3831343134_cluster_4566145593_4566145594_5747234975_768074054_6" s="8.53" t="-1.60" orientation="+" dynamic="yes" zOffset="5" country="OpenDRIVE" type="1000011" subtype="30" height="0.78" width="0.26">
                 <validity fromLane="1" toLane="1"/>
@@ -567,7 +585,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":3182529377_c0" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="0.87067229">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-2.88984528" v="-3.08849385" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="3.53415783" v="2.32373157" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="2.88984528" v="3.08849385" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-3.53415783" v="-2.32373157" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="-534588621#0"/>
     </road>
@@ -616,7 +643,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":cluster_1827996421_1827996431_1827996455_2121324874_#10more_c0" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="0.86882357">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-2.88413059" v="-3.09383108" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="3.52985587" v="2.33026127" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="2.88413059" v="3.09383108" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-3.52985587" v="-2.33026127" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="-534588621#1"/>
     </road>
@@ -902,6 +938,14 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
         </lanes>
         <objects>
             <object id="5520189248" type="natural.tree" name="" s="86.51623307" t="-10.58471051" hdg="0"/>
+            <object id=":2054749637_c0" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="-0.58919482">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="2.19390791" v="-2.38259692" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-1.36251953" v="2.93828871" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-2.19390791" v="2.38259692" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="1.36251953" v="-2.93828871" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
         </objects>
         <signals>
             <signal id="joinedS_2480337678_4566145597_cluster_21487209_3831343134_cluster_4566145593_4566145594_5747234975_768074054_10" s="94.86" t="-1.60" orientation="+" dynamic="yes" zOffset="5" country="OpenDRIVE" type="1000011" subtype="20" height="0.78" width="0.26">
@@ -1027,7 +1071,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":cluster_3792418585_3792418767_c0" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="0.86554738">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-2.02932606" v="-2.35995760" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="2.67296285" v="1.59462652" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="2.02932606" v="2.35995760" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-2.67296285" v="-1.59462652" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="144014234#2"/>
     </road>
@@ -1063,7 +1116,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":cluster_4565322441_5397577486_768038174_863119413_c1" type="crosswalk" name="" s="64.44904409" t="0.00000000" hdg="-2.31609411">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-0.83672223" v="-1.45254807" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="1.51491291" v="0.71766209" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="0.83672223" v="1.45254807" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-1.51491291" v="-0.71766209" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="150394034#2"/>
     </road>
@@ -1170,6 +1232,14 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                     <cornerLocal u="-4.38864260" v="-2.74948080" z="0.00000000" height="0.00000000" id="4"/>
                 </outline>
             </object>
+            <object id=":cluster_1827996511_1827996525_c0" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="2.50783048">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-2.05743844" v="1.95639260" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="1.25149694" v="-2.54838779" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="2.05743844" v="-1.95639260" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-1.25149694" v="2.54838779" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
         </objects>
         <signals/>
         <userData code="sumoId" value="150394035#1"/>
@@ -1228,7 +1298,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":cluster_1827996436_1827996440_c0" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="2.61091598">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-1.94737581" v="2.33789367" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="1.08428700" v="-2.84294585" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="1.94737581" v="-2.33789367" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-1.08428700" v="2.84294585" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="150394035#2"/>
     </road>
@@ -1332,7 +1411,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":cluster_4565322441_5397577486_768038174_863119413_c0" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="0.78539816">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-0.77781746" v="-1.48492424" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="1.48492424" v="0.77781746" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="0.77781746" v="1.48492424" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-1.48492424" v="-0.77781746" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="150394036#1"/>
     </road>
@@ -2021,6 +2109,14 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
         </lanes>
         <objects>
             <object id="1827996462" type="natural.tree" name="" s="67.81504315" t="-13.20442023" hdg="0"/>
+            <object id=":cluster_1827996421_1827996431_1827996455_2121324874_#10more_c5" type="crosswalk" name="" s="72.60777213" t="0.00000000" hdg="2.48078636">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="3.64764211" v="-3.87746158" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-2.85814434" v="4.49121501" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-3.64764211" v="3.87746158" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="2.85814434" v="-4.49121501" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
         </objects>
         <signals>
             <signal id="cluster_1827996421_1827996431_1827996455_2121324874_#10more_0" s="72.61" t="-10.10" orientation="+" dynamic="yes" zOffset="5" country="OpenDRIVE" type="1000011" subtype="20" height="0.78" width="0.26">
@@ -2518,7 +2614,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":cluster_1827996421_1827996431_1827996455_2121324874_#10more_c1" type="crosswalk" name="" s="79.92651718" t="0.00000000" hdg="-0.68534731">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-5.45063480" v="5.87712353" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="4.67643550" v="-6.51006542" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="5.45063480" v="-5.87712353" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-4.67643550" v="6.51006542" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals>
             <signal id="cluster_1827996421_1827996431_1827996455_2121324874_#10more_15" s="79.93" t="-14.40" orientation="+" dynamic="yes" zOffset="5" country="OpenDRIVE" type="1000011" subtype="20" height="0.78" width="0.26">
                 <validity fromLane="1" toLane="1"/>
@@ -2606,7 +2711,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":cluster_1827996421_1827996431_1827996455_2121324874_#10more_c3" type="crosswalk" name="" s="62.91622977" t="0.00000000" hdg="0.91671349">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="2.83052940" v="2.80010785" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-3.43896095" v="-2.00650149" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-2.83052940" v="-2.80010785" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="3.43896095" v="2.00650149" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals>
             <signal id="cluster_1827996421_1827996431_1827996455_2121324874_#10more_23" s="62.92" t="-7.15" orientation="+" dynamic="yes" zOffset="5" country="OpenDRIVE" type="1000011" subtype="20" height="0.78" width="0.26">
                 <validity fromLane="1" toLane="1"/>
@@ -3075,6 +3189,14 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                     <cornerLocal u="-106.18285393" v="-42.44297813" z="0.00000000" height="0.00000000" id="14"/>
                 </outline>
             </object>
+            <object id=":3182529366_c0" type="crosswalk" name="" s="89.02585087" t="0.00000000" hdg="-0.64067857">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-0.69971496" v="0.10197537" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-0.10197537" v="-0.69971496" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="0.69971496" v="-0.10197537" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="0.10197537" v="0.69971496" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
         </objects>
         <signals/>
         <userData code="sumoId" value="24540240#0"/>
@@ -3129,7 +3251,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":cluster_1827996421_1827996431_1827996455_2121324874_#10more_c2" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="2.42274865">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-2.48353220" v="2.07895835" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="1.73096472" v="-2.73747349" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="2.48353220" v="-2.07895835" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-1.73096472" v="2.73747349" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="24913519#1"/>
     </road>
@@ -4401,7 +4532,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":cluster_21487209_3831343134_c0" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="-0.59756883">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="2.21378264" v="-2.36414180" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-1.38707672" v="2.92677607" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-2.21378264" v="2.36414180" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="1.38707672" v="-2.92677607" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="328920970"/>
     </road>
@@ -5320,7 +5460,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":cluster_1827996421_1827996431_1827996455_2121324874_#10more_c4" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="-2.23777376">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="2.79418841" v="2.83637290" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-3.41280243" v="-2.05067786" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-2.79418841" v="-2.83637290" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="3.41280243" v="2.05067786" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="4773465#1"/>
     </road>
@@ -5491,7 +5640,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":341340978_c0" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="-2.27092036">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="2.88984528" v="3.08849385" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-3.53415783" v="-2.32373157" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-2.88984528" v="-3.08849385" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="3.53415783" v="2.32373157" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="534588621#0"/>
     </road>
@@ -6234,7 +6392,16 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":29219440_c0" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="-0.59826841">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="2.21543670" v="-2.36259236" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-1.38912471" v="2.92580502" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-2.21543670" v="2.36259236" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="1.38912471" v="-2.92580502" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="606078069#0"/>
     </road>
@@ -6385,7 +6552,24 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":2480337678_c0" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="0.91400328">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-2.62494118" v="-2.65512406" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="3.23552142" v="1.86316966" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="2.62494118" v="2.65512406" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-3.23552142" v="-1.86316966" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+            <object id=":cluster_21487209_3831343134_c3" type="crosswalk" name="" s="4.72563156" t="0.00000000" hdg="0.91400328">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="2.62494118" v="2.65512406" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-3.23552142" v="-1.86316966" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-2.62494118" v="-2.65512406" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="3.23552142" v="1.86316966" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals>
             <signal id="joinedS_2480337678_4566145597_cluster_21487209_3831343134_cluster_4566145593_4566145594_5747234975_768074054_14" s="4.73" t="-6.90" orientation="+" dynamic="yes" zOffset="5" country="OpenDRIVE" type="1000011" subtype="20" height="0.78" width="0.26">
                 <validity fromLane="1" toLane="1"/>
@@ -6771,7 +6955,24 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":cluster_21487209_3831343134_c1" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="0.89583275">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-2.57626549" v="-2.70237971" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="3.20113437" v="1.92165000" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="2.57626549" v="2.70237971" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-3.20113437" v="-1.92165000" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+            <object id=":cluster_4566145593_4566145594_5747234975_768074054_c0" type="crosswalk" name="" s="11.29432460" t="0.00000000" hdg="0.89583275">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="2.57626549" v="2.70237971" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-3.20113437" v="-1.92165000" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-2.57626549" v="-2.70237971" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="3.20113437" v="1.92165000" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals/>
         <userData code="sumoId" value="61583423#0"/>
     </road>
@@ -6826,7 +7027,24 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                  </right>
             </laneSection>
         </lanes>
-        <objects/>
+        <objects>
+            <object id=":29219440_c3" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="-2.22932498">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="2.62032898" v="2.65967593" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-3.23228281" v="-1.86878244" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-2.62032898" v="-2.65967593" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="3.23228281" v="1.86878244" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+            <object id=":4566145597_c0" type="crosswalk" name="" s="5.66396322" t="0.00000000" hdg="-2.22932498">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-2.62032898" v="-2.65967593" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="3.23228281" v="1.86878244" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="2.62032898" v="2.65967593" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-3.23228281" v="-1.86878244" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+        </objects>
         <signals>
             <signal id="joinedS_2480337678_4566145597_cluster_21487209_3831343134_cluster_4566145593_4566145594_5747234975_768074054_3" s="5.66" t="-6.90" orientation="+" dynamic="yes" zOffset="5" country="OpenDRIVE" type="1000011" subtype="30" height="0.78" width="0.26">
                 <validity fromLane="1" toLane="1"/>
@@ -7127,6 +7345,22 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
                     <cornerLocal u="-7.82534190" v="-68.37965319" z="0.00000000" height="0.00000000" id="30"/>
                 </outline>
             </object>
+            <object id=":29219440_c1" type="crosswalk" name="" s="9.66940593" t="0.00000000" hdg="-2.24230590">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-2.58558414" v="-2.69346518" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="3.20775265" v="1.91058183" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="2.58558414" v="2.69346518" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-3.20775265" v="-1.91058183" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+            <object id=":cluster_4566145593_4566145594_5747234975_768074054_c1" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="-2.24230590">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="2.58558414" v="2.69346518" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-3.20775265" v="-1.91058183" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-2.58558414" v="-2.69346518" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="3.20775265" v="1.91058183" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
         </objects>
         <signals/>
         <userData code="sumoId" value="72157172"/>
@@ -7197,6 +7431,22 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-or-later
         <objects>
             <object id="1296844663" type="amenity.bicycle_rental" name="Karl-Liebknecht-Straße/Spandauer Straße" s="36.57472509" t="-33.05187769" hdg="0"/>
             <object id="4784564100" type="historic.memorial" name="Lutherdenkmal" s="62.45676784" t="-27.10788384" hdg="0"/>
+            <object id=":1827996501_c0" type="crosswalk" name="" s="70.62667079" t="0.00000000" hdg="-0.67170375">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="-3.37851975" v="3.44609987" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="2.59575722" v="-4.06842039" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="3.37851975" v="-3.44609987" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="-2.59575722" v="4.06842039" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
+            <object id=":cluster_1827996421_1827996431_1827996455_2121324874_#10more_c6" type="crosswalk" name="" s="0.00000000" t="0.00000000" hdg="-0.65810385">
+                <outline id="0" fillType="concrete" outer="true" closed="false" laneType="border">
+                    <cornerLocal u="3.33134217" v="-3.49172727" z="0.00000000" height="0.00000000" id="0"/>
+                    <cornerLocal u="-2.54018880" v="4.10334508" z="0.00000000" height="0.00000000" id="1"/>
+                    <cornerLocal u="-3.33134217" v="3.49172727" z="0.00000000" height="0.00000000" id="2"/>
+                    <cornerLocal u="2.54018880" v="-4.10334508" z="0.00000000" height="0.00000000" id="3"/>
+                </outline>
+            </object>
         </objects>
         <signals>
             <signal id="1827996501_0" s="70.63" t="-8.00" orientation="+" dynamic="yes" zOffset="5" country="OpenDRIVE" type="1000011" subtype="30" height="0.78" width="0.26">


### PR DESCRIPTION
This PR includes changes related to exporting crosswalk objects from SUMO networks to OpenDrive format.

For the reviewer: please give your opinion on changes introduced in "writeRoadObjectPoly" method with regards to the t offset, I had to do the changes for properly handling offsets in lefthand conversions, but still some inaccuracies might be there.

![image](https://user-images.githubusercontent.com/1955514/205663533-525f8c68-3d94-4f6a-84db-b121fdb120ee.png)
