### PR TITLE
Typo: code and natural language mixing

### DIFF
--- a/docs/web/docs/TraCI/Interfacing_TraCI_from_Python.md
+++ b/docs/web/docs/TraCI/Interfacing_TraCI_from_Python.md
@@ -402,17 +402,18 @@ time of departure. For details of this mechanism see
 
 ### Retrieve the timeLoss for all vehicles currently in the network
 
-import traci import traci.constants as tc junctionID = '...'
-
-1.  subscribe around an aribtrary junction with a sufficiently large
-    radius to retrieve the speeds of all vehicles in every step
-
-traci.junction.subscribeContext(junctionID,
-tc.CMD_GET_VEHICLE_VARIABLE, 1000000, \[tc.VAR_SPEED,
-tc.VAR_ALLOWED_SPEED\]) stepLength = traci.simulation.getDeltaT()
-while traci.simulation.getMinExpectedNumber() \> 0:
-
 ```
+import traci import traci.constants as tc
+
+junctionID = '...'
+# subscribe around an aribtrary junction with a sufficiently large
+# radius to retrieve the speeds of all vehicles in every step
+traci.junction.subscribeContext(
+    junctionID, tc.CMD_GET_VEHICLE_VARIABLE, 1000000, 
+    [tc.VAR_SPEED, tc.VAR_ALLOWED_SPEED]
+) 
+stepLength = traci.simulation.getDeltaT()
+while traci.simulation.getMinExpectedNumber() > 0:
    traci.simulationStep()
    scResults = traci.junction.getContextSubscriptionResults(junctionID)
    halting = 0
@@ -424,9 +425,8 @@ while traci.simulation.getMinExpectedNumber() \> 0:
        meanSpeedRelative = sum(relSpeeds) / running
        timeLoss = (1 - meanSpeedRelative) * running * stepLength
    print(traci.simulation.getTime(), timeLoss, halting)
-```
-
 traci.close()
+```
 
 ### Handling Exceptions
 


### PR DESCRIPTION
Code and natural natural languages are mixed in a strange way in section ``Retrieve the timeLoss for all vehicles currently in the network`` of ``Interfacing TraCI from Python`` ([website](https://sumo.dlr.de/docs/TraCI/Interfacing_TraCI_from_Python.html#run_a_simulation_until_all_vehicles_have_arrived)). It makes things difficult to read, and prevents quick copy/paste.
![image](https://user-images.githubusercontent.com/72709893/208340210-4c86373f-ecac-4216-939a-00c1a5596b97.png)

As a side note, syntactic highlight would be a plus when reading code. Interested by any pull request?