### PR TITLE
gtfs2pt improvements

### DIFF
--- a/tools/import/gtfs/gtfs2osm.py
+++ b/tools/import/gtfs/gtfs2osm.py
@@ -486,7 +486,7 @@ def map_gtfs_osm(options, net, osm_routes, gtfs_data, shapes, shapes_dict, filte
             if osm_lines:
                 # get the direction for the found routes and take the route
                 # with lower difference
-                diff, osm_id, edges = min(osm_lines, key=lambda x: x[0] if x[0] < 180 else 360 - x[0])
+                diff, osm_id, edges,stops = min(osm_lines, key=lambda x: x[0] if x[0] < 180 else 360 - x[0])
                 # add mapped osm route to dict
                 map_routes[row.shape_id] = (osm_id, edges.split())
             else:
@@ -539,14 +539,14 @@ def map_gtfs_osm(options, net, osm_routes, gtfs_data, shapes, shapes_dict, filte
                 access = getAccess(net, row.stop_lon, row.stop_lat, 100, lane_id)
                 stop_item_id = "%s_%s" % (row.stop_id, len(stop_items[row.stop_id]))
                 stop_items[row.stop_id].append(stop_item_id)
-                map_stops[stop_item_id] = [sumolib.xml.quoteattr(row.stop_name, True),
+                map_stops[stop_item_id] = [sumolib.xml.quoteattr(row.stop_name[0], True),
                                            lane_id, start, end, access, pt_type, edge_inter]
                 _addToDataFrame(gtfs_data, row, shapes_dict, stop_item_id, lane_id.split("_")[0])
                 stop_mapped = True
 
         # if stop not mapped, add to missing stops
         if not stop_mapped:
-            missing_stops.append((row.stop_id, sumolib.xml.quoteattr(row.stop_name, True), row.route_short_name))
+            missing_stops.append((row.stop_id, sumolib.xml.quoteattr(row.stop_name[0], True), row.route_short_name))
 #    pprint(map_routes)
 #    pprint(map_stops)
     return map_routes, map_stops, missing_stops, missing_lines

--- a/tools/import/gtfs/gtfs2osm.py
+++ b/tools/import/gtfs/gtfs2osm.py
@@ -125,7 +125,7 @@ def import_gtfs(options, gtfsZip):
     stop_times['departure_fixed'] = pd.to_timedelta(stop_times.departure_time)
 
     # avoid trimming trips starting before midnight but ending after
-    fix_trips = stop_times[(stop_times['arrival_fixed'] >= full_day) & # gg/ here i arrive at or after midnight
+    fix_trips = stop_times[(stop_times['arrival_fixed'] >= full_day) & 
                            (stop_times['stop_sequence'] == stop_times['stop_sequence'].min())].trip_id.values.tolist()
 
     stop_times.loc[stop_times.trip_id.isin(fix_trips), 'arrival_fixed'] = stop_times.loc[stop_times.trip_id.isin(
@@ -229,11 +229,11 @@ def filter_gtfs(options, routes, trips_on_day, shapes, stops, stop_times):
     gtfs_data["edge_id"] = None
 
     # search main and secondary shapes for each pt line (route and direction)
-    filtered_stops = gtfs_data.groupby(['route_id', 'direction_id', 'shape_id']
-                                       ).agg({'stop_sequence': 'max'}).reset_index()
+    filtered_stops = gtfs_data.groupby(['route_id', 'direction_id', 'shape_id'])["shape_id"].size().reset_index(name='counts')
     group_shapes = filtered_stops.groupby(['route_id', 'direction_id']).shape_id.aggregate(set).reset_index()
-    filtered_stops = filtered_stops.loc[filtered_stops.groupby(['route_id', 'direction_id'])['stop_sequence'].idxmax()][[  # noqa
-                                    'route_id', 'shape_id', 'direction_id']]
+
+    filtered_stops = filtered_stops.loc[filtered_stops.groupby(['route_id', 'direction_id'])['counts'].idxmax()][[  # noqa
+                                        'route_id', 'shape_id', 'direction_id']]
     filtered_stops = pd.merge(filtered_stops, group_shapes, on=['route_id', 'direction_id'])
 
     # create dict with shapes and their main shape

--- a/tools/import/gtfs/gtfs2osm.py
+++ b/tools/import/gtfs/gtfs2osm.py
@@ -125,8 +125,8 @@ def import_gtfs(options, gtfsZip):
     stop_times['departure_fixed'] = pd.to_timedelta(stop_times.departure_time)
 
     # avoid trimming trips starting before midnight but ending after
-    fix_trips = stop_times[(stop_times['arrival_fixed'] >= full_day) &
-                           (stop_times['stop_sequence'] == 0)].trip_id.values.tolist()
+    fix_trips = stop_times[(stop_times['arrival_fixed'] >= full_day) & # gg/ here i arrive at or after midnight
+                           (stop_times['stop_sequence'] == stop_times['stop_sequence'].min())].trip_id.values.tolist()
 
     stop_times.loc[stop_times.trip_id.isin(fix_trips), 'arrival_fixed'] = stop_times.loc[stop_times.trip_id.isin(
         fix_trips), 'arrival_fixed'] % full_day

--- a/tools/import/gtfs/gtfs2pt.py
+++ b/tools/import/gtfs/gtfs2pt.py
@@ -361,24 +361,22 @@ def main(options):
         if routes.empty or trips_on_day.empty:
             return
         if shapes is None:
-            print('Warning: Importing OSM routes currently requires a GTFS file with shapes.', file=sys.stderr)
-            options.osm_routes = None
-        else:
-            (gtfs_data, trip_list,
-             filtered_stops,
-             shapes, shapes_dict) = gtfs2osm.filter_gtfs(options, routes,
-                                                         trips_on_day, shapes,
-                                                         stops, stop_times)
+            print('Warning: GTFS shapes file not found! Continuing mapping without shapes.', file=sys.stderr)
+        (gtfs_data, trip_list,
+            filtered_stops,
+            shapes, shapes_dict) = gtfs2osm.filter_gtfs(options, routes,
+                                                        trips_on_day, shapes,
+                                                        stops, stop_times)
 
-            osm_routes = gtfs2osm.import_osm(options, net)
+        osm_routes = gtfs2osm.import_osm(options, net)
 
-            (mapped_routes, mapped_stops,
-             missing_stops, missing_lines) = gtfs2osm.map_gtfs_osm(options, net, osm_routes, gtfs_data, shapes,
-                                                                   shapes_dict, filtered_stops)
+        (mapped_routes, mapped_stops,
+            missing_stops, missing_lines) = gtfs2osm.map_gtfs_osm(options, net, osm_routes, gtfs_data, shapes,
+                                                                shapes_dict, filtered_stops)
 
-            gtfs2osm.write_gtfs_osm_outputs(options, mapped_routes, mapped_stops,
-                                            missing_stops, missing_lines,
-                                            gtfs_data, trip_list, shapes_dict, net)
+        gtfs2osm.write_gtfs_osm_outputs(options, mapped_routes, mapped_stops,
+                                        missing_stops, missing_lines,
+                                        gtfs_data, trip_list, shapes_dict, net)
     if not options.osm_routes:
         # Import PT from GTFS
         if not options.skip_fcd:


### PR DESCRIPTION
**1. Filter stops by most common shape instead of longest shape**
- This filters out stops that are not commonly in route nor likely to be present in OSM route

**2. Map OSM routes without shapes file** 
- Used the same principle as with using shapes, took the first and last stop (rather than first and last shape coordinate) to get an estimate of the direction of route 

**3. Map GTFS to OSM routes only when,**
- they share at least one common stop. This prevents mapping to completely different lines with the same name.
- they have smaller than 160 degrees angle difference. This prevents mapping to route in opposite direction if correct direction is not available.

**4. Parse PT line color from ptlines.xml to create colored vehicles**

- [ ] Requires modifying ptlines.xml prior to add default color, so PT lines without color are also parsed

