### PR TITLE
fix: code blocks

### DIFF
--- a/docs/web/docs/TraCI/Interfacing_TraCI_from_Python.md
+++ b/docs/web/docs/TraCI/Interfacing_TraCI_from_Python.md
@@ -15,13 +15,13 @@ can be found at
 To use the library, the {{SUMO}}/tools directory must be on the python load
 path. This is typically done with a stanza like this:
 
-```
- import os, sys
- if 'SUMO_HOME' in os.environ:
-     tools = os.path.join(os.environ['SUMO_HOME'], 'tools')
-     sys.path.append(tools)
- else:
-     sys.exit("please declare environment variable 'SUMO_HOME'")
+```python
+import os, sys
+if 'SUMO_HOME' in os.environ:
+    tools = os.path.join(os.environ['SUMO_HOME'], 'tools')
+    sys.path.append(tools)
+else:
+    sys.exit("please declare environment variable 'SUMO_HOME'")
 ```
 
 This assumes that the [environment variable
@@ -29,8 +29,8 @@ This assumes that the [environment variable
 is set before running the script. Alternatively, you can declare the
 path to *sumo/tools* directly as in the line
 
-```
-sys.path.append(os.path.join('c:', os.sep, 'whatever', 'path', 'to', 'sumo', 'tools'))
+```python
+sys.path.append(os.path.join('c:', os.sep, 'whatever', 'path', 'to', 'sumo', 'tools'))
 ```
 
 ## First Steps
@@ -43,22 +43,22 @@ First you compose the command line to start either
 [sumo](../sumo.md) or [sumo-gui](../sumo-gui.md) (leaving out
 the option  which was needed before 0.28.0):
 
-```
-sumoBinary = "/path/to/sumo-gui"
-sumoCmd = [sumoBinary, "-c", "yourConfiguration.sumocfg"]
+```python
+sumoBinary = "/path/to/sumo-gui"
+sumoCmd = [sumoBinary, "-c", "yourConfiguration.sumocfg"]
 ```
 
 Then you start the simulation and connect to it with your script:
 
-```
-import traci
+```python
+import traci
 traci.start(sumoCmd)
-step = 0
-while step < 1000:
-   traci.simulationStep()
-   if traci.inductionloop.getLastStepVehicleNumber("0") > 0:
-       traci.trafficlight.setRedYellowGreenState("0", "GrGr")
-   step += 1
+step = 0
+while step < 1000:
+    traci.simulationStep()
+    if traci.inductionloop.getLastStepVehicleNumber("0") > 0:
+        traci.trafficlight.setRedYellowGreenState("0", "GrGr")
+    step += 1
 
 traci.close()
 ```
@@ -68,7 +68,7 @@ execute simulation steps until you want to finish by closing the
 connection. By default, the close command will wait until the sumo
 process really finishes. You can disable this by calling:
 
-```
+```python
 traci.close(False)
 ```
 
@@ -83,17 +83,17 @@ each time step. In order to subscribe for variables you need to know
 their variable ids which can be looked up in the traci/constants.py
 file.
 
-```
-import traci
-import traci.constants as tc
+```python
+import traci
+import traci.constants as tc
 
-traci.start(["sumo", "-c", "my.sumocfg"])
-traci.vehicle.subscribe(vehID, (tc.VAR_ROAD_ID, tc.VAR_LANEPOSITION))
+traci.start(["sumo", "-c", "my.sumocfg"])
+traci.vehicle.subscribe(vehID, (tc.VAR_ROAD_ID, tc.VAR_LANEPOSITION))
 print(traci.vehicle.getSubscriptionResults(vehID))
-for step in range(3):
-   print("step", step)
-   traci.simulationStep()
-   print(traci.vehicle.getSubscriptionResults(vehID))
+for step in range(3):
+    print("step", step)
+    traci.simulationStep()
+    print(traci.vehicle.getSubscriptionResults(vehID))
 traci.close()
 ```
 
@@ -117,17 +117,17 @@ always has the form CMD_GET_<DOMAIN\>_VARIABLE. The following code
 retrieves all vehicle speeds and waiting times within range (42m) of a
 junction (the vehicle ids are retrieved implicitly).
 
-```
-import traci
-import traci.constants as tc
+```python
+import traci
+import traci.constants as tc
 
-traci.start(["sumo", "-c", "my.sumocfg"])
-traci.junction.subscribeContext(junctionID, tc.CMD_GET_VEHICLE_VARIABLE, 42, [tc.VAR_SPEED, tc.VAR_WAITING_TIME])
+traci.start(["sumo", "-c", "my.sumocfg"])
+traci.junction.subscribeContext(junctionID, tc.CMD_GET_VEHICLE_VARIABLE, 42, [tc.VAR_SPEED, tc.VAR_WAITING_TIME])
 print(traci.junction.getContextSubscriptionResults(junctionID))
-for step in range(3):
-   print("step", step)
-   traci.simulationStep()
-   print(traci.junction.getContextSubscriptionResults(junctionID))
+for step in range(3):
+    print("step", step)
+    traci.simulationStep()
+    print(traci.junction.getContextSubscriptionResults(junctionID))
 traci.close()
 ```
 
@@ -145,9 +145,9 @@ directly after the call to `subscribeContext()` by a successive call to
 `addSubscriptionFilter<FILTER_ID>()` as for instance in the following
 snippet:
 
-```
-traci.vehicle.subscribeContext("ego", tc.CMD_GET_VEHICLE_VARIABLE, 0.0, [tc.VAR_SPEED])
-traci.vehicle.addSubscriptionFilterLanes(lanes, noOpposite=True, downstreamDist=100, upstreamDist=50)
+```python
+traci.vehicle.subscribeContext("ego", tc.CMD_GET_VEHICLE_VARIABLE, 0.0, [tc.VAR_SPEED])
+traci.vehicle.addSubscriptionFilterLanes(lanes, noOpposite=True, downstreamDist=100, upstreamDist=50)
 ```
 
 The first line requests a context subscription for the speed of vehicles
@@ -189,16 +189,16 @@ traci.simulationStep() is called, to let this happen automatically
 StepListener object 'listener' (more precisely an instance of a subclass
 of traci.StepListener) i.e.
 
-```
- class ExampleListener(traci.StepListener):
-    def step(self, t):
-        # do something after every call to simulationStep
-        print("ExampleListener called with parameter %s." % t)
-        # indicate that the step listener should stay active in the next step
-        return True
-       
- listener = ExampleListener()
- traci.addStepListener(listener)
+```python
+class ExampleListener(traci.StepListener):
+    def step(self, t):
+        # do something after every call to simulationStep
+        print("ExampleListener called with parameter %s." % t)
+        # indicate that the step listener should stay active in the next step
+        return True
+
+listener = ExampleListener()
+traci.addStepListener(listener)
 ```
 Please note that the listener is not activated for every simulation step
 but for every call to simulationStep (which may perform multiple steps up to the given time *t*).
@@ -216,17 +216,17 @@ optional label argument which allows you to call it multiple times with
 different simulation instances and labels. The function *traci.switch()*
 can then be used to switch to any of the initialized labels:
 
-```
- traci.start(["sumo", "-c", "sim1.sumocfg"], label="sim1")
- traci.start(["sumo", "-c", "sim2.sumocfg"], label="sim2")
- traci.switch("sim1")
- traci.simulationStep() # run 1 step for sim1
- traci.switch("sim2")
- traci.simulationStep() # run 1 step for sim2 
- traci.switch("sim1")
- traci.close()
- traci.switch("sim2")
- traci.close()
+```python
+traci.start(["sumo", "-c", "sim1.sumocfg"], label="sim1")
+traci.start(["sumo", "-c", "sim2.sumocfg"], label="sim2")
+traci.switch("sim1")
+traci.simulationStep() # run 1 step for sim1
+traci.switch("sim2")
+traci.simulationStep() # run 1 step for sim2 
+traci.switch("sim1")
+traci.close()
+traci.switch("sim2")
+traci.close()
 ```
 
 If you prefer a more object oriented approach you can also use
@@ -234,13 +234,13 @@ connection objects to communicate with the simulation. They have the
 same interface as the static *traci.* calls but you will still need to
 start the simulation manually for them:
 
-```
- traci.start(["sumo", "-c", "sim1.sumocfg"], label="sim1")
- traci.start(["sumo", "-c", "sim2.sumocfg"], label="sim2")
- conn1 = traci.getConnection("sim1")
- conn2 = traci.getConnection("sim2")
- conn1.simulationStep() # run 1 step for sim1
- conn2.simulationStep() # run 1 step for sim2
+```python
+traci.start(["sumo", "-c", "sim1.sumocfg"], label="sim1")
+traci.start(["sumo", "-c", "sim2.sumocfg"], label="sim2")
+conn1 = traci.getConnection("sim1")
+conn2 = traci.getConnection("sim2")
+conn1.simulationStep() # run 1 step for sim1
+conn2.simulationStep() # run 1 step for sim2
 ```
 
 ## Controlling the same simulation from multiple clients
@@ -251,9 +251,9 @@ be known to all clients. After deciding on a port it can be made
 available to the clients via arguments or configuration files. A free
 port can be obtained by
 
-```
-from sumolib.miscutils import getFreeSocketPort
-port = sumolib.miscutils.getFreeSocketPort()
+```python
+from sumolib.miscutils import getFreeSocketPort
+port = sumolib.miscutils.getFreeSocketPort()
 ```
 
 One client may use method *traci.start()* to start the simulation and
@@ -261,25 +261,25 @@ connect to it at the same time while the other client only needs to
 connect. After establishing client order, each client must continuously
 call *simulationStep* to allow the simulation to advance:
 
-```
+```python
 #client1
-# PORT = int(sys.argv[1]) # example
-traci.start(["sumo", "-c", "sim.sumocfg", "--num-clients", "2"], port=PORT)
-traci.setOrder(1) # number can be anything
-while traci.simulation.getMinExpectedNumber() > 0:
-   traci.simulationStep()
-   # more traci commands
-traci.close(
+# PORT = int(sys.argv[1]) # example
+traci.start(["sumo", "-c", "sim.sumocfg", "--num-clients", "2"], port=PORT)
+traci.setOrder(1) # number can be anything
+while traci.simulation.getMinExpectedNumber() > 0:
+    traci.simulationStep()
+    # more traci commands
+traci.close()
 ```
 
-```
-# client2
-# PORT = int(sys.argv[1]) # example
+```python
+# client2
+# PORT = int(sys.argv[1]) # example
 traci.init(PORT)
-traci.setOrder(2) # number can be anything as long as each client gets its own number
-while traci.simulation.getMinExpectedNumber() > 0:
-   traci.simulationStep()
-   # more traci commands
+traci.setOrder(2) # number can be anything as long as each client gets its own number
+while traci.simulation.getMinExpectedNumber() > 0:
+    traci.simulationStep()
+    # more traci commands
 traci.close()
 ```
 
@@ -309,7 +309,7 @@ For this functionality it is recommended to use
 ### Determine the traci library being loaded
 When working with different sumo versions it may happen that the call `import traci` loads the wrong library.
 The easiest way to debug this is to add the following lines after the import
-```
+```python
 import traci
 print("LOADPATH:", '\n'.join(sys.path))                                                                                                                                      
 print("TRACIPATH:", traci.__file__) 
@@ -325,8 +325,8 @@ below steps make it simple to run sumo with traci in a debugger:
 
 1\) Add the option *--save-configuration* to your traci script:
 
-```
-traci.start([sumoBinary, '-c', 'run.sumocfg', '--save-configuration', 'debug.sumocfg'])
+```python
+traci.start([sumoBinary, '-c', 'run.sumocfg', '--save-configuration', 'debug.sumocfg'])
 ```
 
 2\) Run your traci script. Instead of starting sumo it will just write
@@ -336,7 +336,7 @@ repeatedly.
 3\) Run
 
 ```
-gdb --args sumoD -c debug.sumocfg
+gdb --args sumoD -c debug.sumocfg
 ```
 
 (where sumoD is sumo [compiled in debug
@@ -366,23 +366,23 @@ After the script fails to start, look into the written logfile and fix the error
 
 ### Run a simulation until all vehicles have arrived
 
-```
-  while traci.simulation.getMinExpectedNumber() > 0:
-      traci.simulationStep()
+```python
+while traci.simulation.getMinExpectedNumber() > 0:
+    traci.simulationStep()
 ```
 
 ### Add trips (incomplete routes) dynamically
 
 Define a route that consists of the start and destination edge:
 
-```
-   traci.route.add("trip", ["startEdge", "endEdge"])
+```python
+traci.route.add("trip", ["startEdge", "endEdge"])
 ```
 
 Then add the vehicle with that route
 
-```
-   traci.vehicle.add("newVeh", "trip", typeID="reroutingType")
+```python
+traci.vehicle.add("newVeh", "trip", typeID="reroutingType")
 ```
 
 This will cause the vehicle to compute a new route from startEdge to
@@ -392,20 +392,20 @@ time of departure. For details of this mechanism see
 
 ### coordinate transformations
 
-```
- x, y = traci.vehicle.getPosition(vehID)
- lon, lat = traci.simulation.convertGeo(x, y)
- x2, y2 = traci.simulation.convertGeo(lon, lat, fromGeo=True)
+```python
+x, y = traci.vehicle.getPosition(vehID)
+lon, lat = traci.simulation.convertGeo(x, y)
+x2, y2 = traci.simulation.convertGeo(lon, lat, fromGeo=True)
 ```
 
-```
- edgeID, lanePosition, laneIndex = traci.simulation.convertRoad(x3, y3)
- edgeID, lanePosition, laneIndex = traci.simulation.convertRoad(lon2, lat2, True)
+```python
+edgeID, lanePosition, laneIndex = traci.simulation.convertRoad(x3, y3)
+edgeID, lanePosition, laneIndex = traci.simulation.convertRoad(lon2, lat2, True)
 ```
 
 ### Retrieve the timeLoss for all vehicles currently in the network
 
-```
+```python
 import traci
 import traci.constants as tc
 traci.start(["sumo", "-c", "my.sumocfg"])
@@ -419,17 +419,17 @@ traci.junction.subscribeContext(
 ) 
 stepLength = traci.simulation.getDeltaT()
 while traci.simulation.getMinExpectedNumber() > 0:
-   traci.simulationStep()
-   scResults = traci.junction.getContextSubscriptionResults(junctionID)
-   halting = 0
-   if scResults:
-       relSpeeds = [d[tc.VAR_SPEED] / d[tc.VAR_ALLOWED_SPEED] for d in scResults.values()]
-       # compute values corresponding to summary-output
-       running = len(relSpeeds)
-       halting = len([1 for d in scResults.values() if d[tc.VAR_SPEED] < 0.1])
-       meanSpeedRelative = sum(relSpeeds) / running
-       timeLoss = (1 - meanSpeedRelative) * running * stepLength
-   print(traci.simulation.getTime(), timeLoss, halting)
+    traci.simulationStep()
+    scResults = traci.junction.getContextSubscriptionResults(junctionID)
+    halting = 0
+    if scResults:
+        relSpeeds = [d[tc.VAR_SPEED] / d[tc.VAR_ALLOWED_SPEED] for d in scResults.values()]
+        # compute values corresponding to summary-output
+        running = len(relSpeeds)
+        halting = len([1 for d in scResults.values() if d[tc.VAR_SPEED] < 0.1])
+        meanSpeedRelative = sum(relSpeeds) / running
+        timeLoss = (1 - meanSpeedRelative) * running * stepLength
+    print(traci.simulation.getTime(), timeLoss, halting)
 traci.close()
 ```
 
@@ -438,7 +438,7 @@ traci.close()
 Sometimes commands raise an (recoverable) exception to indicate an error (unknown id, route not found etc.). These exceptions
 can be handled by your code as follows:
 
-```
+```python
 try:
     pos = traci.vehicle.getPosition(vehID)
 except traci.TraCIException:


### PR DESCRIPTION
fix: code indentation
fix: missing )
fix: use spaces instead of non-breakable spaces
add: python flag to markdown code blocks containing python code