### PR TITLE
Update Jupedsim integration with API changes

### DIFF
--- a/src/microsim/transportables/MSPModel_JuPedSim.cpp
+++ b/src/microsim/transportables/MSPModel_JuPedSim.cpp
@@ -60,8 +60,6 @@ MSPModel_JuPedSim::~MSPModel_JuPedSim() {
 
     JPS_Simulation_Free(myJPSSimulation);
     JPS_OperationalModel_Free(myJPSModel);
-    JPS_Areas_Free(myJPSAreas);
-    JPS_AreasBuilder_Free(myJPSAreasBuilder);
     JPS_Geometry_Free(myJPSGeometry);
     JPS_GeometryBuilder_Free(myJPSGeometryBuilder);
 
@@ -103,9 +101,10 @@ MSPModel_JuPedSim::add(MSTransportable* person, MSStageMoving* stage, SUMOTime n
     const MSLane* arrivalLane = getSidewalk<MSEdge, MSLane>(stage->getRoute().back());
     Position arrivalPosition = arrivalLane->getShape().positionAtOffset(stage->getArrivalPos());
 
-	JPS_Waypoint waypoints[] = { {{arrivalPosition.x(), arrivalPosition.y()}, JPS_EXIT_TOLERANCE} };
-	JPS_Journey journey = JPS_Journey_Create_SimpleJourney(waypoints, sizeof(waypoints));
+	JPS_Journey journey = JPS_Journey_Create();
+    JPS_Journey_AddWaypoint(journey, {arrivalPosition.x(), arrivalPosition.y()}, JPS_EXIT_TOLERANCE);
     JPS_JourneyId journeyId = JPS_Simulation_AddJourney(myJPSSimulation, journey, nullptr);
+    JPS_Journey_Free(journey);
 
 	JPS_VelocityModelAgentParameters agent_parameters{};
 	agent_parameters.journeyId = journeyId;
@@ -562,8 +561,6 @@ MSPModel_JuPedSim::initialize() {
         WRITE_ERROR(oss.str());
     }
 
-    myJPSAreasBuilder = JPS_AreasBuilder_Create();
-    myJPSAreas = JPS_AreasBuilder_Build(myJPSAreasBuilder, nullptr);
 
     JPS_VelocityModelBuilder modelBuilder = JPS_VelocityModelBuilder_Create(8.0, 0.1, 5.0, 0.02);
     myJPSParameterProfileId = 1;
@@ -577,7 +574,7 @@ MSPModel_JuPedSim::initialize() {
         WRITE_ERROR(oss.str());
     }
 
-	myJPSSimulation = JPS_Simulation_Create(myJPSModel, myJPSGeometry, myJPSAreas, STEPS2TIME(JPS_DELTA_T), &message);
+	myJPSSimulation = JPS_Simulation_Create(myJPSModel, myJPSGeometry, STEPS2TIME(JPS_DELTA_T), &message);
     if (myJPSSimulation == nullptr) {
         std::ostringstream oss;
         oss << "Error while creating the simulation: " << JPS_ErrorMessage_GetMessage(message);

--- a/src/microsim/transportables/MSPModel_JuPedSim.h
+++ b/src/microsim/transportables/MSPModel_JuPedSim.h
@@ -124,8 +124,6 @@ private:
 
     JPS_GeometryBuilder myJPSGeometryBuilder;
     JPS_Geometry myJPSGeometry;
-    JPS_AreasBuilder myJPSAreasBuilder;
-    JPS_Areas myJPSAreas;
     JPS_OperationalModel myJPSModel;
     JPS_ModelParameterProfileId myJPSParameterProfileId;
     JPS_Simulation myJPSSimulation;


### PR DESCRIPTION
API Changes addressed:

* Areas/AreaBuilder has been removed.

* Journeys are now constructed piece-by-piece and contain exits explicityly. Adding additional wypoints AFTER an exit is not-yet an error but pointless as Agents get removed when entering the polygon defining the exit area.

NOTE: The polygon describing the exit area hast to be a CCW defined simple convex polygon.

Example:

```
JPS_JourneyId j = JPS_Journey_Create();
JPS_Journey_AddWaypoint(JPS_Point{4,4}, 0.5);
JPS_Journey_AddWaypoint(JPS_Point{3,3}, 0.5);
JPS_Journey_AddWaypoint(JPS_Point{2,2}, 0.5);
JPS_Point exit[] = {{-0.5, -0.5}, {-0.5, 0.5}, {0.5, 0.5}, {0.5, -0.5}};
JPS_Journey_AddExit(journey, exit, 4);
// later...
JPS_Journey_Free(journey);

```