### PR TITLE
Check for division by 0 in norm computation

### DIFF
--- a/src/utils/geom/Position.h
+++ b/src/utils/geom/Position.h
@@ -161,11 +161,13 @@ public:
         myZ -= pos.myZ;
     }
 
-    /// @brief
+    /// @brief Normalises the given 2d position
     void norm2d() {
         const double val = sqrt(myX * myX + myY * myY);
-        myX /= val;
-        myY /= val;
+        if (val != 0.0) {
+            myX /= val;
+            myY /= val;
+        }
     }
 
     /// @brief output operator


### PR DESCRIPTION
## In this PR, the following functionalities have been added

- Check for 0 norm before dividing the position values 
- Docstring for the `norm2d` method