### PR TITLE
Use more generic limits for network coordinates range

### DIFF
--- a/tools/sumolib/net/__init__.py
+++ b/tools/sumolib/net/__init__.py
@@ -166,7 +166,7 @@ class Net:
         self._nodes = []
         self._edges = []
         self._tlss = []
-        self._ranges = [[10000, -10000], [10000, -10000]]
+        self._ranges = [[sys.float_info.max, -sys.float_info.max], [sys.float_info.max, -sys.float_info.max]]
         self._roundabouts = []
         self._rtreeEdges = None
         self._rtreeLanes = None


### PR DESCRIPTION
TL;DR: Default values for min/max were not large/small enough for the coordinates range to be properly calculated in sumolib tools.

Although network files use the offset to make sure coordinates are not too far from (0, 0), in some cases coordinates may have values outside the expected range [-10000, 10000], so -10000 and 10000 are not the best default values when calculating min/max coordinates.

Additionally, in my use case, I need to perform additional processing using multiple data sources and different network files, so it is best for me to have all network files in the same projection, but most importantly, **all network files need to have an offset of (0, 0) so they align properly**. In this case, because the offset is (0, 0), all coordinates are pretty far from (0,0), and this issue of -10000 and 10000 not being small/large enough becomes apparent.