### PR TITLE
[tools] tileGet - get tiles in parallel

### DIFF
--- a/tools/sumolib/net/__init__.py
+++ b/tools/sumolib/net/__init__.py
@@ -166,7 +166,7 @@ class Net:
         self._nodes = []
         self._edges = []
         self._tlss = []
-        self._ranges = [[10000, -10000], [10000, -10000]]
+        self._ranges = [[sys.float_info.max, -sys.float_info.max], [sys.float_info.max, -sys.float_info.max]]
         self._roundabouts = []
         self._rtreeEdges = None
         self._rtreeLanes = None

--- a/tools/tileGet.py
+++ b/tools/tileGet.py
@@ -110,7 +110,7 @@ def retrieveMapServerTiles(options, west, south, east, north, decals, net):
             filename = os.path.join(options.output_dir, "%s%s_%s.jpeg" % (options.prefix, x, y))
             
             if options.parallel_jobs == 0:
-                worker(x, y, zoom, options, decals, net, request, filename)
+                worker(options, request, filename)
                 # i += 1
                 # print("{%f}% ({%s})" % (100.0 * (i+1)/N, request))
             else:

--- a/tools/tileGet.py
+++ b/tools/tileGet.py
@@ -106,12 +106,10 @@ def retrieveMapServerTiles(options, west, south, east, north, decals, net):
                     x, y, executor.submit(worker, x, y, zoom, options, decals, net, request, filename)
                 ))
 
-        i = 0
-        for (x, y, future) in futures:
+        for i, (x, y, future) in enumerate(futures):
             future.result()
 
-            i += 1
-            print(f"{(100.0 * i/N):.2f}% ({request})")
+            # print(f"{(100.0 * (i+1)/N):.2f}% ({request})")
             
             if net is not None:
                 lat, lon = fromTileToLatLon(x, y, zoom)

--- a/tools/tileGet.py
+++ b/tools/tileGet.py
@@ -100,38 +100,49 @@ def retrieveMapServerTiles(options, west, south, east, north, decals, net):
         original_sigint_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
         pool = Pool(options.parallel_jobs)
         signal.signal(signal.SIGINT, original_sigint_handler)
-    
-    futures = []
 
-    # i = 0
-    for x in range(sx, ex + 1):
-        for y in range(sy, ey + 1):
-            request = "%s/%s/%s/%s" % (options.url, zoom, y, x)
-            filename = os.path.join(options.output_dir, "%s%s_%s.jpeg" % (options.prefix, x, y))
-            
-            if options.parallel_jobs == 0:
-                worker(options, request, filename)
-                # i += 1
-                # print("{%f}% ({%s})" % (100.0 * (i+1)/N, request))
-            else:
+        futures = []
+
+        # i = 0
+        for x in range(sx, ex + 1):
+            for y in range(sy, ey + 1):
+                request = "%s/%s/%s/%s" % (options.url, zoom, y, x)
+                filename = os.path.join(options.output_dir, "%s%s_%s.jpeg" % (options.prefix, x, y))
+                
                 futures.append((
                     x, y, pool.apply_async(worker, (options, request, filename))
                 ))
 
-    for i, (x, y, future) in enumerate(futures):
-        future.get()
+        for i, (x, y, future) in enumerate(futures):
+            future.get()
 
-        # print('%f%% (%s)' % (100.0 * (i+1)/N, request))
-        if net is not None:
-        
-            lat, lon = fromTileToLatLon(x, y, zoom)
-            upperLeft = net.convertLonLat2XY(lon, lat)
-            lat, lon = fromTileToLatLon(x + 0.5, y + 0.5, zoom)
-            center = net.convertLonLat2XY(lon, lat)
-            print('    <decal file="%s" centerX="%s" centerY="%s" width="%s" height="%s" layer="%d"/>' %
-                    (os.path.basename(filename), center[0], center[1],
-                    2 * (center[0] - upperLeft[0]), 2 * (upperLeft[1] - center[1]), options.layer), file=decals)
+            # print('%f%% (%s)' % (100.0 * (i+1)/N, request))
+            if net is not None:
+            
+                lat, lon = fromTileToLatLon(x, y, zoom)
+                upperLeft = net.convertLonLat2XY(lon, lat)
+                lat, lon = fromTileToLatLon(x + 0.5, y + 0.5, zoom)
+                center = net.convertLonLat2XY(lon, lat)
+                print('    <decal file="%s" centerX="%s" centerY="%s" width="%s" height="%s" layer="%d"/>' %
+                        (os.path.basename(filename), center[0], center[1],
+                        2 * (center[0] - upperLeft[0]), 2 * (upperLeft[1] - center[1]), options.layer), file=decals)
+    else:
+        for x in range(sx, ex + 1):
+            for y in range(sy, ey + 1):
+                request = "%s/%s/%s/%s" % (options.url, zoom, y, x)
+                filename = os.path.join(options.output_dir, "%s%s_%s.jpeg" % (options.prefix, x, y))
+                
+                worker(options, request, filename)
+                
+                if net is not None:
 
+                    lat, lon = fromTileToLatLon(x, y, zoom)
+                    upperLeft = net.convertLonLat2XY(lon, lat)
+                    lat, lon = fromTileToLatLon(x + 0.5, y + 0.5, zoom)
+                    center = net.convertLonLat2XY(lon, lat)
+                    print('    <decal file="%s" centerX="%s" centerY="%s" width="%s" height="%s" layer="%d"/>' %
+                            (os.path.basename(filename), center[0], center[1],
+                            2 * (center[0] - upperLeft[0]), 2 * (upperLeft[1] - center[1]), options.layer), file=decals)
 
 def get_options(args=None):
     optParser = sumolib.options.ArgumentParser()

--- a/tools/tileGet.py
+++ b/tools/tileGet.py
@@ -234,11 +234,11 @@ def get(args=None):
 
 
 if __name__ == "__main__":
-    # try:
+    try:
         get()
-    # except urlerror as e:
-    #     print("Error: Tile server returned %s." % e, file=sys.stderr)
-    #     if e.code == 403:
-    #         print(" Maybe an API key is required.", file=sys.stderr)
-    # except ValueError as e:
-    #     print("Error: Tile server returned %s." % e, file=sys.stderr)
+    except urlerror as e:
+        print("Error: Tile server returned %s." % e, file=sys.stderr)
+        if e.code == 403:
+            print(" Maybe an API key is required.", file=sys.stderr)
+    except ValueError as e:
+        print("Error: Tile server returned %s." % e, file=sys.stderr)


### PR DESCRIPTION
Tile providers (namely ArcGIS) have high throughput but high latency. This means it takes a considerable amount of time to get one tile, but many tiles can be requested in parallel to increase throughput drastically.

I suggest using a thread pool to process multiple tile requests in parallel. The thread pool has 8 threads, which means at most 8 requests are being processed simultaneously.

Processing a tile is mostly server-intensive on the side of the tile provider, so in theory we could make all requests upfront in parallel and asynchronously wait for all the responses from the tile provider, which would still incur almost no CPU usage on the client side (since we're only getting relatively small images and storing them). But this would cause excessive load on the tile provider, and we could risk getting throttled by the tile provider. Hence why the thread pool only has 8 threads.

Still, this solution drastically reduces execution time for tileGet.py, which is especially beneficial when downloading large numbers of tiles to obtain a high-quality background for SUMO.